### PR TITLE
Add conversation count fields to PR list and detail APIs

### DIFF
--- a/backend/dtos/prDetailDto.ts
+++ b/backend/dtos/prDetailDto.ts
@@ -12,6 +12,8 @@ export class PRDetailDto implements PRDetail {
   number: number;
   title: string;
   body: string;
+  commentsCount: number;
+  reviewCommentsCount: number;
   assignees: PRDetail['assignees'];
   author: PRDetail['author'];
   createdAt: string;
@@ -25,6 +27,8 @@ export class PRDetailDto implements PRDetail {
     this.number = data.number;
     this.title = data.title;
     this.body = data.body;
+    this.commentsCount = data.commentsCount;
+    this.reviewCommentsCount = data.reviewCommentsCount;
     this.assignees = data.assignees;
     this.author = data.author;
     this.createdAt = data.createdAt;
@@ -39,10 +43,18 @@ export class PRDetailDto implements PRDetail {
     raw: GhPRDetail,
     inlineCommentsByReview: Map<string, GhReviewInlineComment[]>
   ): PRDetailDto {
+    const reviewCommentsCount = raw.reviews.reduce(
+      (total, review) =>
+        total + (inlineCommentsByReview.get(review.id)?.length ?? 0),
+      0
+    );
+
     return new PRDetailDto({
       number: raw.number,
       title: raw.title,
       body: isString(raw.body) ? raw.body : '',
+      commentsCount: raw.comments.length,
+      reviewCommentsCount,
       assignees: raw.assignees.map((a) => ({
         id: a.id ?? a.login,
         login: a.login,

--- a/backend/dtos/pullRequestsDto.ts
+++ b/backend/dtos/pullRequestsDto.ts
@@ -5,6 +5,8 @@ export class PRListItemDto implements PRListItem {
   number: number;
   title: string;
   body: string;
+  commentsCount: number;
+  reviewCommentsCount: number;
   assignees: PRListItem['assignees'];
   author: PRListItem['author'];
   createdAt: string;
@@ -15,6 +17,8 @@ export class PRListItemDto implements PRListItem {
     this.number = data.number;
     this.title = data.title;
     this.body = data.body;
+    this.commentsCount = data.commentsCount;
+    this.reviewCommentsCount = data.reviewCommentsCount;
     this.assignees = data.assignees;
     this.author = data.author;
     this.createdAt = data.createdAt;
@@ -29,6 +33,8 @@ export class PRListItemDto implements PRListItem {
       number: pr.number,
       title: pr.title,
       body: isString(pr.body) ? pr.body : '',
+      commentsCount: pr.comments ?? 0,
+      reviewCommentsCount: pr.review_comments ?? 0,
       assignees: pr.assignees.map((user) => ({
         id: String(user.id),
         login: user.login,

--- a/backend/services/pullRequests.test.ts
+++ b/backend/services/pullRequests.test.ts
@@ -22,6 +22,8 @@ describe('pullRequests service', () => {
         number: 1,
         title: 'Test PR',
         body: 'Test body',
+        comments: 3,
+        review_comments: 5,
         assignees: [{ id: 1, login: 'user1', name: 'User One', type: 'User' }],
         user: { id: 2, login: 'author1', name: 'Author One', type: 'User' },
         created_at: '2024-01-01T00:00:00Z',
@@ -32,6 +34,8 @@ describe('pullRequests service', () => {
         number: 2,
         title: 'Another PR',
         body: null,
+        comments: 0,
+        review_comments: 2,
         assignees: [],
         user: { id: 3, login: 'author2', type: 'Bot' },
         created_at: '2024-01-03T00:00:00Z',
@@ -45,6 +49,8 @@ describe('pullRequests service', () => {
         number: 1,
         title: 'Test PR',
         body: 'Test body',
+        commentsCount: 3,
+        reviewCommentsCount: 5,
         assignees: [{ id: '1', login: 'user1', name: 'User One' }],
         author: { id: '2', login: 'author1', name: 'Author One' },
         createdAt: '2024-01-01T00:00:00Z',
@@ -55,6 +61,8 @@ describe('pullRequests service', () => {
         number: 2,
         title: 'Another PR',
         body: '',
+        commentsCount: 0,
+        reviewCommentsCount: 2,
         assignees: [],
         author: {
           id: '3',
@@ -81,6 +89,93 @@ describe('pullRequests service', () => {
         'api',
         'repos/owner/repo/pulls?per_page=100&page=1&state=open',
       ]);
+      expect(mockExecAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should default counts to 0 when GitHub fields are missing', async () => {
+      const withoutCountFields = [
+        {
+          number: 3,
+          title: 'No counts PR',
+          body: 'Body',
+          assignees: [],
+          user: { id: 4, login: 'author3', name: 'Author Three', type: 'User' },
+          created_at: '2024-01-05T00:00:00Z',
+          updated_at: '2024-01-06T00:00:00Z',
+          state: 'open',
+        },
+      ];
+
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: JSON.stringify(withoutCountFields),
+        stderr: '',
+      });
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: JSON.stringify({ comments: 9, review_comments: 4 }),
+        stderr: '',
+      });
+
+      const result = await fetchPRList('owner/repo');
+
+      expect(result[0].commentsCount).toBe(9);
+      expect(result[0].reviewCommentsCount).toBe(4);
+    });
+
+    it('should default counts to 0 when GitHub fields are null', async () => {
+      const nullCountFields = [
+        {
+          number: 4,
+          title: 'Null counts PR',
+          body: 'Body',
+          comments: null,
+          review_comments: null,
+          assignees: [],
+          user: { id: 5, login: 'author4', name: 'Author Four', type: 'User' },
+          created_at: '2024-01-07T00:00:00Z',
+          updated_at: '2024-01-08T00:00:00Z',
+          state: 'open',
+        },
+      ];
+
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: JSON.stringify(nullCountFields),
+        stderr: '',
+      });
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: JSON.stringify({ comments: 6, review_comments: 2 }),
+        stderr: '',
+      });
+
+      const result = await fetchPRList('owner/repo');
+
+      expect(result[0].commentsCount).toBe(6);
+      expect(result[0].reviewCommentsCount).toBe(2);
+    });
+
+    it('should fallback to 0 when detail lookup for missing counts fails', async () => {
+      const withoutCountFields = [
+        {
+          number: 5,
+          title: 'Missing counts PR',
+          body: 'Body',
+          assignees: [],
+          user: { id: 6, login: 'author5', name: 'Author Five', type: 'User' },
+          created_at: '2024-01-09T00:00:00Z',
+          updated_at: '2024-01-10T00:00:00Z',
+          state: 'open',
+        },
+      ];
+
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: JSON.stringify(withoutCountFields),
+        stderr: '',
+      });
+      mockExecAsync.mockRejectedValueOnce(new Error('detail lookup failed'));
+
+      const result = await fetchPRList('owner/repo');
+
+      expect(result[0].commentsCount).toBe(0);
+      expect(result[0].reviewCommentsCount).toBe(0);
     });
 
     it('should pass page and limit options', async () => {
@@ -190,6 +285,8 @@ describe('pullRequests service', () => {
       number: 1,
       title: 'Test PR',
       body: 'Test body',
+      commentsCount: 1,
+      reviewCommentsCount: 0,
       assignees: [{ id: '1', login: 'user1', name: 'User One' }],
       author: { id: '2', login: 'author1', name: 'Author One' },
       createdAt: '2024-01-01T00:00:00Z',

--- a/backend/services/pullRequests.ts
+++ b/backend/services/pullRequests.ts
@@ -87,8 +87,56 @@ export async function fetchPRList(
   }
 
   const prs = JSON.parse(stdout) as GitHubPullRequest[];
+  const prsWithCounts = await enrichMissingConversationCounts(
+    repoOwnerName,
+    prs
+  );
 
-  return prs.map((pr) => PRListItemDto.fromGitHub(pr));
+  return prsWithCounts.map((pr) => PRListItemDto.fromGitHub(pr));
+}
+
+async function enrichMissingConversationCounts(
+  repoOwnerName: string,
+  prs: GitHubPullRequest[]
+): Promise<GitHubPullRequest[]> {
+  return Promise.all(
+    prs.map(async (pr) => {
+      const hasCommentsCount = typeof pr.comments === 'number';
+      const hasReviewCommentsCount = typeof pr.review_comments === 'number';
+
+      if (hasCommentsCount && hasReviewCommentsCount) {
+        return pr;
+      }
+
+      try {
+        const { stdout } = await execFileAsync('gh', [
+          'api',
+          `repos/${repoOwnerName}/pulls/${pr.number}`,
+        ]);
+        const prDetail = JSON.parse(stdout) as {
+          comments?: number | null;
+          review_comments?: number | null;
+        };
+
+        return {
+          ...pr,
+          comments: pr.comments ?? prDetail.comments ?? 0,
+          review_comments: pr.review_comments ?? prDetail.review_comments ?? 0,
+        };
+      } catch (err) {
+        console.error(
+          `[fetchPRList] Failed to fetch conversation counts for PR #${pr.number}:`,
+          err
+        );
+
+        return {
+          ...pr,
+          comments: pr.comments ?? 0,
+          review_comments: pr.review_comments ?? 0,
+        };
+      }
+    })
+  );
 }
 
 /**

--- a/backend/types/pullRequests.ts
+++ b/backend/types/pullRequests.ts
@@ -9,6 +9,8 @@ export type GitHubPullRequest = {
   number: number;
   title: string;
   body?: string | null;
+  comments?: number | null;
+  review_comments?: number | null;
   assignees: GitHubUser[];
   user: GitHubUser;
   created_at: string;
@@ -108,6 +110,8 @@ export interface PRListItem {
   number: number;
   title: string;
   body: string;
+  commentsCount: number;
+  reviewCommentsCount: number;
   assignees: PRAssignee[];
   author: PRAuthor;
   createdAt: string;


### PR DESCRIPTION
## Summary

- Add `commentsCount` and `reviewCommentsCount` fields to PR list and detail DTOs
- Implement fallback logic to fetch missing conversation counts from individual PR details when GitHub's list API omits these fields
- Handle graceful degradation to 0 when count data is unavailable or fetch fails

## Implementation Details

```mermaid
graph TD
    A[PR List Request] --> B[GitHub List API]
    B --> C{Has counts?}
    C -->|Yes| D[Use GitHub counts]
    C -->|No| E[Fetch PR Detail]
    E --> F{Detail Success?}
    F -->|Yes| G[Use detail counts]
    F -->|No| H[Fallback to 0]
    D --> I[Return DTO]
    G --> I
    H --> I
```

### Data Flow

The enrichment logic checks if `comments` and `review_comments` fields exist in the GitHub list response. When missing, it makes an additional API call to fetch individual PR details, falling back to 0 on errors to ensure resilient behavior.

For PR detail view, `commentsCount` is derived from the `comments` array length, and `reviewCommentsCount` is calculated by summing inline comments across all reviews.

## Test Coverage

Added comprehensive test cases covering:
- PRs with complete count data
- PRs with missing count fields
- PRs with null count values
- Error handling during detail lookup fallback

Made with [Cursor](https://cursor.com)