### PR TITLE
feat: support configurable DB path via DB_PATH env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Path to the SQLite database file.
+# Defaults to ~/.lgtmai/lgtmai.db if not set.
+DB_PATH=/custom/path/to/lgtmai.db

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 .DS_Store
 .worktrees/
 .vscode
+.env
 
 # Prisma
 */generated/

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "postinstall": "prisma generate",
     "build": "tsoa routes && node esbuild.config.mjs",
-    "dev": "prisma migrate dev && tsoa spec && tsoa routes && (tsx watch index.ts || true)",
+    "dev": "dotenv -e ../.env -c -- sh -c 'prisma migrate dev && tsoa spec && tsoa routes && (tsx watch index.ts || true)'",
     "start": "prisma migrate deploy && node dist/index.js",
     "lint": "eslint .",
     "test": "vitest run",
@@ -40,6 +40,7 @@
     "@types/node": "^18.19.0",
     "@types/swagger-ui-express": "^4.1.8",
     "@types/ws": "^8.18.1",
+    "dotenv-cli": "^11.0.0",
     "esbuild": "^0.27.3",
     "eslint": "^9.39.2",
     "globals": "^17.3.0",

--- a/backend/prisma.config.ts
+++ b/backend/prisma.config.ts
@@ -1,8 +1,7 @@
-import path from 'node:path';
-import os from 'node:os';
 import { defineConfig } from 'prisma/config';
+import { resolveDbPath } from './utils/dbPath.js';
 
-const dbPath = path.join(os.homedir(), '.lgtmai', 'lgtmai.db');
+const dbPath = resolveDbPath();
 
 export default defineConfig({
   schema: 'prisma/schema.prisma',

--- a/backend/prismaClient.ts
+++ b/backend/prismaClient.ts
@@ -1,13 +1,13 @@
 import path from 'node:path';
-import os from 'node:os';
 import { mkdirSync } from 'node:fs';
 import { PrismaLibSql } from '@prisma/adapter-libsql';
 import { PrismaClient } from '@prisma/client';
+import { resolveDbPath } from './utils/dbPath.js';
 
-const dbDir = path.join(os.homedir(), '.lgtmai');
+const dbPath = resolveDbPath();
+const dbDir = path.dirname(dbPath);
 mkdirSync(dbDir, { recursive: true });
 
-const dbPath = path.join(dbDir, 'lgtmai.db');
 const adapter = new PrismaLibSql({ url: `file:${dbPath}` });
 const prisma = new PrismaClient({ adapter });
 

--- a/backend/startup/runMigrations.ts
+++ b/backend/startup/runMigrations.ts
@@ -1,10 +1,10 @@
 import { execFile } from 'node:child_process';
 import { mkdirSync } from 'node:fs';
-import os from 'node:os';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import { resolveDbPath } from '../utils/dbPath.js';
 
 type ExecFileAsync = (
   file: string,
@@ -43,7 +43,7 @@ export async function runStartupMigrations(
   options: RunStartupMigrationsOptions = {}
 ): Promise<void> {
   const backendRoot = resolveBackendRoot(options.backendRoot);
-  const dbDir = join(os.homedir(), '.lgtmai');
+  const dbDir = dirname(resolveDbPath());
   mkdirSync(dbDir, { recursive: true });
 
   const schemaPath =

--- a/backend/utils/dbPath.ts
+++ b/backend/utils/dbPath.ts
@@ -1,0 +1,9 @@
+import path from 'node:path';
+import os from 'node:os';
+
+export function resolveDbPath(): string {
+  const defaultDbPath = path.join(os.homedir(), '.lgtmai', 'lgtmai.db');
+  const rawPath = process.env.DB_PATH ?? defaultDbPath;
+  const expandedPath = rawPath.replace(/^~/, os.homedir());
+  return path.resolve(expandedPath);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      dotenv-cli:
+        specifier: ^11.0.0
+        version: 11.0.0
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3
@@ -1935,8 +1938,20 @@ packages:
     resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
     engines: {node: '>=20'}
 
+  dotenv-cli@11.0.0:
+    resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
+    hasBin: true
+
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -5583,7 +5598,20 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  dotenv-cli@11.0.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      dotenv: 17.3.1
+      dotenv-expand: 12.0.3
+      minimist: 1.2.8
+
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.6.1
+
   dotenv@16.6.1: {}
+
+  dotenv@17.3.1: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Introduce `resolveDbPath()` utility in `backend/utils/dbPath.ts` that reads `DB_PATH` from the environment, expands `~` to the home directory, and resolves to an absolute path — with fallback to `~/.lgtmai/lgtmai.db`
- Consolidate previously duplicated DB path logic across `prismaClient.ts`, `prisma.config.ts`, and `runMigrations.ts` into this single utility
- Load `.env` automatically in the `dev` script via `dotenv-cli`; production (`npx lgtmai`) relies on the user setting `DB_PATH` via `export`

## How it works

```
DB_PATH env var (optional)
        │
        ▼
  resolveDbPath()
  ┌─────────────────────────────────────┐
  │ 1. Read DB_PATH or use default path │
  │ 2. Expand ~ → os.homedir()          │
  │ 3. path.resolve() → absolute path   │
  └─────────────────────────────────────┘
        │
        ▼
  prismaClient.ts / prisma.config.ts / runMigrations.ts
```

Closes #59