### PR TITLE
docs: distribute CLAUDE.md across monorepo packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,47 +1,35 @@
 # Project Overview
 
-LGTM AI automates PR review application using Claude Code. This is a pnpm workspaces monorepo with three packages: `cli`, `backend`, `frontend`.
+LGTM AI automates PR review using Claude Code. pnpm workspaces monorepo: `cli`, `backend`, `frontend`.
 
 # Common Commands
 
 ```bash
-# Build all workspaces
-pnpm run build
+pnpm run build          # Build all workspaces
+pnpm run dev            # Backend + frontend with file watching
+pnpm start              # Run CLI from source
+pnpm test               # Run tests (all packages)
 
-# Development (backend + frontend with file watching)
-pnpm run dev
-
-# Run CLI from source
-pnpm start
-
-# Build and run specific workspace
 pnpm --filter @lgtmai/cli build
 pnpm --filter @lgtmai/backend dev
 ```
 
 # Architecture
 
-**IMPORTANT**: This is a monorepo. The CLI orchestrates backend (Express on :5051) and frontend (Vite on :5050) as child processes.
+The CLI orchestrates backend (Express :5051) and frontend (Vite :5050) as child processes. Frontend proxies `/api/*` to backend.
 
-- `cli/`: Validates `gh` and `claude` CLIs, launches servers, opens browser
-- `backend/`: Express API server (proxied via `/api` in frontend)
-- `frontend/`: React 19 + Vite UI
-
-Port config in `cli/utils/ports.ts`. Frontend proxies `/api/*` to backend.
+- `cli/`: Validates `gh`/`claude` CLIs, launches servers, opens browser. Port config: `cli/utils/ports.ts`
+- `backend/`: Express + tsoa API server.
+- `frontend/`: React 19 + Vite UI.
 
 # Prerequisites
 
-The CLI requires these tools installed and authenticated:
 - GitHub CLI (`gh auth login`)
 - Claude Code CLI
 
 # Publishing
 
 `bin/lgtmai.js` wraps `cli/dist/index.js`. `prepublishOnly` builds all workspaces.
-
-# Coding Rules
-
-- **Backend tsoa imports**: Always import from `@tsoa/runtime`, never from `tsoa`. The `tsoa` package is a build-time code generation tool and is excluded from the production bundle via esbuild externals.
 
 # GitHub Write Actions Policy
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -27,6 +27,11 @@ SQLite via Prisma + libsql adapter. Schema: `prisma/schema.prisma`.
 - Default DB path: `~/.lgtmai/lgtmai.db` (override with `DB_PATH` env var)
 - Dev: `prisma migrate dev` | Prod: `prisma migrate deploy`
 
+## Conventions
+
+- Public methods must always be placed above private methods.
+- Prefer declarative, functional programming style using remeda for data transformation logic.
+
 ## Error Handling
 
 Use `AppError` (with `statusCode`) for HTTP errors. The error middleware also catches tsoa's `ValidateError` and returns consistent JSON responses.
@@ -40,3 +45,5 @@ Messages from server: `text`, `tool_message`, `tool_result`, `done`, `error`, `a
 ## Testing
 
 Vitest. Unit tests: `.test.ts`. Integration tests: `.int.test.ts` (use `createTestDatabase()` from `test/prismaTestDb.ts` for isolated DB instances).
+
+- When adding tests, always review at the end to ensure there are no excessive or duplicate test cases.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,42 @@
+# Backend Architecture
+
+Express + tsoa + Prisma (SQLite via libsql).
+
+## Structure
+
+Flat structure — no `src/` directory. Key folders:
+
+- `controllers/` — tsoa route controllers
+- `services/` — pure functions (no classes)
+- `repositories/` — DB access functions
+- `types/` — shared types exported from `types/index.ts`
+- `prisma/` — schema and migrations
+
+## tsoa
+
+Controllers use decorators (`@Route`, `@Get`, `@Post`, etc.) and extend `Controller` from `@tsoa/runtime`.
+
+**IMPORTANT**: Always import from `@tsoa/runtime`, never from `tsoa`. The `tsoa` package is build-time only and excluded from the esbuild bundle.
+
+Build pipeline: `tsoa spec && tsoa routes` → esbuild. Routes and Swagger are auto-generated — run tsoa before building.
+
+## Database
+
+SQLite via Prisma + libsql adapter. Schema: `prisma/schema.prisma`.
+
+- Default DB path: `~/.lgtmai/lgtmai.db` (override with `DB_PATH` env var)
+- Dev: `prisma migrate dev` | Prod: `prisma migrate deploy`
+
+## Error Handling
+
+Use `AppError` (with `statusCode`) for HTTP errors. The error middleware also catches tsoa's `ValidateError` and returns consistent JSON responses.
+
+## WebSocket
+
+`/api/claude/execute` streams Claude Code execution using the `ws` library.
+Messages from client: `execute`, `followUp`, `abort`, `approval_response`, `plan_approval_response`.
+Messages from server: `text`, `tool_message`, `tool_result`, `done`, `error`, `approval_request`, `file_changes`, etc.
+
+## Testing
+
+Vitest. Unit tests: `.test.ts`. Integration tests: `.int.test.ts` (use `createTestDatabase()` from `test/prismaTestDb.ts` for isolated DB instances).

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -29,7 +29,7 @@ SQLite via Prisma + libsql adapter. Schema: `prisma/schema.prisma`.
 
 ## Conventions
 
-- Public methods must always be placed above private methods.
+- Order methods by caller → callee (top-down readability); public methods above private.
 - Prefer declarative, functional programming style using remeda for data transformation logic.
 
 ## Error Handling

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -18,7 +18,7 @@ Controllers use decorators (`@Route`, `@Get`, `@Post`, etc.) and extend `Control
 
 **IMPORTANT**: Always import from `@tsoa/runtime`, never from `tsoa`. The `tsoa` package is build-time only and excluded from the esbuild bundle.
 
-Build pipeline: `tsoa spec && tsoa routes` → esbuild. Routes and Swagger are auto-generated — run tsoa before building.
+Build pipeline: `tsoa routes` → esbuild. In dev, `tsoa spec` also runs to generate `swagger.json` (swagger is not served in production). Routes are auto-generated — run `tsoa routes` before building.
 
 ## Database
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,5 +1,7 @@
 # Frontend Architecture
 
+React 19 + Vite + React Query + Tailwind CSS 4.
+
 ## Folder Structure (Layer Hierarchy)
 
 ```
@@ -17,6 +19,17 @@ src/
 - **domains**: Hooks, components, and pages used only within each domain (Projects, PRList, PRDetail)
 - **features**: Code with business logic shared across multiple domains
 - **shared**: Pure utilities and UI components with no business logic
+
+## API Layer
+
+Each domain has its own folder under `shared/apis/{domain}/`:
+
+- `index.ts` — fetch functions
+- `query.ts` — React Query query hooks
+- `mutation.ts` — React Query mutation hooks
+- `queryKey.ts` — query key factory
+
+Low-level fetch utilities (`apiGet`, `apiPost`, etc.) are in `shared/apis/client.ts`. Use `ApiClientError` for error handling.
 
 ## Component Convention
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -18,7 +18,7 @@ src/
 
 - **domains**: Hooks, components, and pages used only within each domain (Projects, PRList, PRDetail)
 - **features**: Code with business logic shared across multiple domains
-- **shared**: Pure utilities and UI components with no business logic
+- **shared**: Pure utilities, UI components, and API layer (fetch functions + React Query hooks shared across domains)
 
 ## API Layer
 


### PR DESCRIPTION
## Summary

- Split root `CLAUDE.md` into package-level files to reduce noise and keep each file focused on its scope
- Created `backend/CLAUDE.md` covering backend-specific architecture: tsoa build pipeline, database setup, error handling, and WebSocket protocol
- Enhanced `frontend/CLAUDE.md` with API layer patterns (per-domain `query.ts`/`mutation.ts`/`queryKey.ts` structure) and tech stack overview

Root `CLAUDE.md` now serves as a lightweight entry point with pointers to package-level docs.