### PR TITLE
feat: add batch execute WebSocket message for multi-comment actions

### DIFF
--- a/backend/controllers/ClaudeWSController.ts
+++ b/backend/controllers/ClaudeWSController.ts
@@ -108,10 +108,17 @@ export function handleClaudeWebSocket(ws: WebSocket): void {
     }
 
     if (msg.type === 'batchExecute') {
-      const { requestId, workingDir, options, chatContext } = msg;
-      const batchMsg = msg as WsBatchExecuteMessage;
+      const {
+        requestId,
+        workingDir,
+        options,
+        chatContext,
+        command,
+        contexts,
+        customPrompt,
+      } = msg as WsBatchExecuteMessage;
 
-      if (!batchMsg.contexts || batchMsg.contexts.length === 0) {
+      if (!contexts || contexts.length === 0) {
         ws.send(
           JSON.stringify({
             type: 'error',
@@ -125,12 +132,8 @@ export function handleClaudeWebSocket(ws: WebSocket): void {
       let userPrompt: string;
       let systemPrompt: string;
       try {
-        systemPrompt = buildSystemPrompt(batchMsg.contexts[0]);
-        userPrompt = buildBatchUserPrompt(
-          batchMsg.command,
-          batchMsg.contexts,
-          batchMsg.customPrompt
-        );
+        systemPrompt = buildSystemPrompt(contexts[0]);
+        userPrompt = buildBatchUserPrompt(command, contexts, customPrompt);
       } catch (err) {
         ws.send(
           JSON.stringify({
@@ -149,7 +152,7 @@ export function handleClaudeWebSocket(ws: WebSocket): void {
         workingDir,
         options,
         chatContext,
-        { command: batchMsg.command, customPrompt: batchMsg.customPrompt },
+        { command, customPrompt },
         systemPrompt
       );
       return;

--- a/backend/controllers/ClaudeWSController.ts
+++ b/backend/controllers/ClaudeWSController.ts
@@ -3,10 +3,12 @@ import { ClaudeSessionManager } from '../services/claude/ClaudeSessionManager.js
 import {
   buildSystemPrompt,
   buildUserPrompt,
+  buildBatchUserPrompt,
 } from '../services/promptBuilder.js';
 import type {
   WsClientMessage,
   WsCommandExecuteMessage,
+  WsBatchExecuteMessage,
 } from '../types/claude.js';
 
 export function handleClaudeWebSocket(ws: WebSocket): void {
@@ -101,6 +103,54 @@ export function handleClaudeWebSocket(ws: WebSocket): void {
         behavior,
         message,
         updatedInput
+      );
+      return;
+    }
+
+    if (msg.type === 'batchExecute') {
+      const { requestId, workingDir, options, chatContext } = msg;
+      const batchMsg = msg as WsBatchExecuteMessage;
+
+      if (!batchMsg.contexts || batchMsg.contexts.length === 0) {
+        ws.send(
+          JSON.stringify({
+            type: 'error',
+            requestId,
+            message: 'contexts must be a non-empty array',
+          })
+        );
+        return;
+      }
+
+      let userPrompt: string;
+      let systemPrompt: string;
+      try {
+        systemPrompt = buildSystemPrompt(batchMsg.contexts[0]);
+        userPrompt = buildBatchUserPrompt(
+          batchMsg.command,
+          batchMsg.contexts,
+          batchMsg.customPrompt
+        );
+      } catch (err) {
+        ws.send(
+          JSON.stringify({
+            type: 'error',
+            requestId,
+            message:
+              err instanceof Error ? err.message : 'Failed to build prompt',
+          })
+        );
+        return;
+      }
+
+      manager.execute(
+        requestId,
+        userPrompt,
+        workingDir,
+        options,
+        chatContext,
+        { command: batchMsg.command, customPrompt: batchMsg.customPrompt },
+        systemPrompt
       );
       return;
     }

--- a/backend/services/promptBuilder.test.ts
+++ b/backend/services/promptBuilder.test.ts
@@ -260,6 +260,16 @@ describe('buildBatchUserPrompt', () => {
       expect(result).toContain('This variable name is unclear');
       expect(result).toContain('Missing null check here');
     });
+
+    it('includes diff hunk when present', () => {
+      const result = buildBatchUserPrompt('explain', batchContexts);
+      expect(result).toContain('x.doSomething()');
+    });
+
+    it('includes file path when present', () => {
+      const result = buildBatchUserPrompt('explain', batchContexts);
+      expect(result).toContain('src/utils/helper.ts');
+    });
   });
 
   describe('validate', () => {
@@ -305,15 +315,5 @@ describe('buildBatchUserPrompt', () => {
     expect(() =>
       buildBatchUserPrompt('unknown' as ClaudeCommand, batchContexts)
     ).toThrow();
-  });
-
-  it('includes diff hunk when present', () => {
-    const result = buildBatchUserPrompt('explain', batchContexts);
-    expect(result).toContain('x.doSomething()');
-  });
-
-  it('includes file path when present', () => {
-    const result = buildBatchUserPrompt('explain', batchContexts);
-    expect(result).toContain('src/utils/helper.ts');
   });
 });

--- a/backend/services/promptBuilder.test.ts
+++ b/backend/services/promptBuilder.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { buildSystemPrompt, buildUserPrompt } from './promptBuilder.js';
+import {
+  buildSystemPrompt,
+  buildUserPrompt,
+  buildBatchUserPrompt,
+} from './promptBuilder.js';
 import type { CommandContext, PRMeta, ClaudeCommand } from '../types/claude.js';
 
 const prMeta: PRMeta = {
@@ -204,5 +208,112 @@ describe('buildUserPrompt', () => {
     expect(() =>
       buildUserPrompt('unknown' as ClaudeCommand, reviewContext)
     ).toThrow('Unknown command: unknown');
+  });
+});
+
+const batchContexts = [
+  {
+    type: 'review' as const,
+    author: 'alice',
+    body: 'This variable name is unclear',
+    prMeta,
+  },
+  {
+    type: 'comment' as const,
+    author: 'bob',
+    body: 'Missing null check here',
+    path: 'src/utils/helper.ts',
+    diffHunk:
+      '@@ -10,6 +10,8 @@\n function helper() {\n+  const x = getValue();\n+  x.doSomething();',
+    prMeta,
+  },
+];
+
+describe('buildBatchUserPrompt', () => {
+  describe('fix', () => {
+    it('includes all comment authors', () => {
+      const result = buildBatchUserPrompt('fix', batchContexts);
+      expect(result).toContain('alice');
+      expect(result).toContain('bob');
+    });
+
+    it('numbers each comment', () => {
+      const result = buildBatchUserPrompt('fix', batchContexts);
+      expect(result).toContain('[1]');
+      expect(result).toContain('[2]');
+    });
+
+    it('includes instruction to not use git', () => {
+      const result = buildBatchUserPrompt('fix', batchContexts);
+      expect(result).toContain('Do NOT use git commands');
+    });
+
+    it('includes instruction to summarize per comment', () => {
+      const result = buildBatchUserPrompt('fix', batchContexts);
+      expect(result).toContain('per comment');
+    });
+  });
+
+  describe('explain', () => {
+    it('includes all comment bodies', () => {
+      const result = buildBatchUserPrompt('explain', batchContexts);
+      expect(result).toContain('This variable name is unclear');
+      expect(result).toContain('Missing null check here');
+    });
+  });
+
+  describe('validate', () => {
+    it('includes VALID/INVALID instructions', () => {
+      const result = buildBatchUserPrompt('validate', batchContexts);
+      expect(result).toContain('VALID');
+      expect(result).toContain('INVALID');
+    });
+
+    it('numbers each comment', () => {
+      const result = buildBatchUserPrompt('validate', batchContexts);
+      expect(result).toContain('[1]');
+      expect(result).toContain('[2]');
+    });
+  });
+
+  describe('custom', () => {
+    it('includes custom prompt and all contexts', () => {
+      const result = buildBatchUserPrompt(
+        'custom',
+        batchContexts,
+        'Check security'
+      );
+      expect(result).toContain('Check security');
+      expect(result).toContain('alice');
+      expect(result).toContain('bob');
+    });
+
+    it('throws if customPrompt is missing', () => {
+      expect(() => buildBatchUserPrompt('custom', batchContexts)).toThrow(
+        'customPrompt is required'
+      );
+    });
+  });
+
+  it('throws on review command', () => {
+    expect(() => buildBatchUserPrompt('review', batchContexts)).toThrow(
+      "Command 'review' is not supported for batch"
+    );
+  });
+
+  it('throws on unknown command', () => {
+    expect(() =>
+      buildBatchUserPrompt('unknown' as ClaudeCommand, batchContexts)
+    ).toThrow();
+  });
+
+  it('includes diff hunk when present', () => {
+    const result = buildBatchUserPrompt('explain', batchContexts);
+    expect(result).toContain('x.doSomething()');
+  });
+
+  it('includes file path when present', () => {
+    const result = buildBatchUserPrompt('explain', batchContexts);
+    expect(result).toContain('src/utils/helper.ts');
   });
 });

--- a/backend/services/promptBuilder.ts
+++ b/backend/services/promptBuilder.ts
@@ -9,15 +9,6 @@ import type {
 import { AppError } from '../errors/AppError.js';
 import * as templates from './promptTemplates.js';
 
-function requireCustomPrompt(customPrompt?: string): void {
-  if (!customPrompt || customPrompt.trim() === '') {
-    throw new AppError(
-      'customPrompt is required for custom command',
-      HttpStatus.BAD_REQUEST
-    );
-  }
-}
-
 export function buildSystemPrompt(context: CommandContext): string {
   if (context.type === 'pr') {
     return templates.systemPromptForPR(context.prMeta);
@@ -105,5 +96,15 @@ export function buildBatchUserPrompt(
         `Command '${command}' is not supported for batch`,
         HttpStatus.BAD_REQUEST
       );
+  }
+}
+
+
+function requireCustomPrompt(customPrompt?: string): void {
+  if (!customPrompt || customPrompt.trim() === '') {
+    throw new AppError(
+      'customPrompt is required for custom command',
+      HttpStatus.BAD_REQUEST
+    );
   }
 }

--- a/backend/services/promptBuilder.ts
+++ b/backend/services/promptBuilder.ts
@@ -79,3 +79,34 @@ function buildReviewCommentUserPrompt(
       throw new AppError(`Unknown command: ${command}`, HttpStatus.BAD_REQUEST);
   }
 }
+
+export function buildBatchUserPrompt(
+  command: ClaudeCommand,
+  contexts: (ReviewCommandContext | CommentCommandContext)[],
+  customPrompt?: string
+): string {
+  const batchSection = templates.batchReviewCommentSection(contexts);
+
+  switch (command) {
+    case 'fix':
+      return templates.batchFixPrompt(batchSection);
+    case 'explain':
+      return templates.batchExplainPrompt(batchSection);
+    case 'validate':
+      return templates.batchValidatePrompt(batchSection);
+    case 'custom': {
+      if (!customPrompt || customPrompt.trim() === '') {
+        throw new AppError(
+          'customPrompt is required for custom command',
+          HttpStatus.BAD_REQUEST
+        );
+      }
+      return templates.batchCustomPrompt(customPrompt, batchSection);
+    }
+    default:
+      throw new AppError(
+        `Command '${command}' is not supported for batch`,
+        HttpStatus.BAD_REQUEST
+      );
+  }
+}

--- a/backend/services/promptBuilder.ts
+++ b/backend/services/promptBuilder.ts
@@ -9,6 +9,15 @@ import type {
 import { AppError } from '../errors/AppError.js';
 import * as templates from './promptTemplates.js';
 
+function requireCustomPrompt(customPrompt?: string): void {
+  if (!customPrompt || customPrompt.trim() === '') {
+    throw new AppError(
+      'customPrompt is required for custom command',
+      HttpStatus.BAD_REQUEST
+    );
+  }
+}
+
 export function buildSystemPrompt(context: CommandContext): string {
   if (context.type === 'pr') {
     return templates.systemPromptForPR(context.prMeta);
@@ -40,10 +49,8 @@ function buildPrUserPrompt(
     case 'explain':
       return templates.explainPrPrompt(repoOwnerName, prNumber);
     case 'custom': {
-      if (!customPrompt || customPrompt.trim() === '') {
-        throw new Error('customPrompt is required for custom command');
-      }
-      return templates.customPrPrompt(customPrompt, repoOwnerName, prNumber);
+      requireCustomPrompt(customPrompt);
+      return templates.customPrPrompt(customPrompt!, repoOwnerName, prNumber);
     }
     default:
       throw new Error(
@@ -67,13 +74,8 @@ function buildReviewCommentUserPrompt(
     case 'validate':
       return templates.validatePrompt(reviewComment);
     case 'custom': {
-      if (!customPrompt || customPrompt.trim() === '') {
-        throw new AppError(
-          'customPrompt is required for custom command',
-          HttpStatus.BAD_REQUEST
-        );
-      }
-      return templates.customPrompt(customPrompt, reviewComment);
+      requireCustomPrompt(customPrompt);
+      return templates.customPrompt(customPrompt!, reviewComment);
     }
     default:
       throw new AppError(`Unknown command: ${command}`, HttpStatus.BAD_REQUEST);
@@ -95,13 +97,8 @@ export function buildBatchUserPrompt(
     case 'validate':
       return templates.batchValidatePrompt(batchSection);
     case 'custom': {
-      if (!customPrompt || customPrompt.trim() === '') {
-        throw new AppError(
-          'customPrompt is required for custom command',
-          HttpStatus.BAD_REQUEST
-        );
-      }
-      return templates.batchCustomPrompt(customPrompt, batchSection);
+      requireCustomPrompt(customPrompt);
+      return templates.batchCustomPrompt(customPrompt!, batchSection);
     }
     default:
       throw new AppError(

--- a/backend/services/promptTemplates.ts
+++ b/backend/services/promptTemplates.ts
@@ -178,3 +178,60 @@ export function customPrPrompt(
 ## PR Context
 Use \`gh pr diff ${prNumber} --repo ${repoOwnerName}\` to view the full diff if needed.`;
 }
+
+// ── Batch prompt templates ──────────────────────────────────────────
+
+export function batchReviewCommentSection(
+  contexts: ReviewCommentParams[]
+): string {
+  return contexts
+    .map((ctx, i) => `### [${i + 1}]\n${reviewCommentSection(ctx)}`)
+    .join('\n\n');
+}
+
+export function batchFixPrompt(batchSection: string): string {
+  return `Multiple reviewers left the following comments. Apply all suggested fixes to the codebase.
+
+## Review Comments
+${batchSection}
+
+## Instructions
+- Address each comment in order ([1], [2], ...)
+- Read relevant files before making changes
+- Do NOT use git commands — only modify local files
+- After all changes, briefly summarize what you changed per comment`;
+}
+
+export function batchExplainPrompt(batchSection: string): string {
+  return `Multiple reviewers left the following comments. Explain what each reviewer is pointing out and why it matters.
+
+## Review Comments
+${batchSection}
+
+## Instructions
+1. For each comment ([1], [2], ...), summarize what the reviewer is asking for in plain language
+2. Explain WHY it matters (performance, readability, correctness, etc.)
+3. If applicable, show a brief code example of what the fix would look like`;
+}
+
+export function batchValidatePrompt(batchSection: string): string {
+  return `Evaluate whether each of the following review comments is a valid, actionable code review suggestion.
+
+## Review Comments
+${batchSection}
+
+## Instructions
+For each comment ([1], [2], ...), respond with VALID or INVALID, then explain in 1-2 sentences:
+- VALID: points out a real issue, is specific, and can be addressed with code changes
+- INVALID: is vague, incorrect, stylistic nitpick without substance, or not actionable`;
+}
+
+export function batchCustomPrompt(
+  userPrompt: string,
+  batchSection: string
+): string {
+  return `${userPrompt}
+
+## Review Comments Context
+${batchSection}`;
+}

--- a/backend/types/claude.ts
+++ b/backend/types/claude.ts
@@ -68,6 +68,17 @@ export interface WsCommandExecuteMessage {
   chatContext?: ClaudeChatContext;
 }
 
+export interface WsBatchExecuteMessage {
+  type: 'batchExecute';
+  requestId: string;
+  workingDir: string;
+  command: ClaudeCommand;
+  contexts: (ReviewCommandContext | CommentCommandContext)[];
+  customPrompt?: string;
+  options?: ClaudeExecuteOptions;
+  chatContext?: ClaudeChatContext;
+}
+
 export interface WsFollowUpExecuteMessage {
   type: 'followUp';
   requestId: string;
@@ -109,7 +120,8 @@ export type WsClientMessage =
   | WsFollowUpExecuteMessage
   | WsAbortMessage
   | WsApprovalResponseMessage
-  | WsPlanApprovalResponseMessage;
+  | WsPlanApprovalResponseMessage
+  | WsBatchExecuteMessage;
 
 // ── Server → Client ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add `batchExecute` WebSocket message type that accepts multiple review/comment contexts and processes them in a single Claude session
- Add batch prompt templates (fix, explain, validate, custom) that aggregate numbered review comments into structured prompts
- Extend `buildBatchUserPrompt` in promptBuilder with full test coverage

```mermaid
sequenceDiagram
    participant Client
    participant WS as ClaudeWSController
    participant PB as PromptBuilder
    participant Claude as ClaudeSessionManager

    Client->>WS: batchExecute { command, contexts[] }
    WS->>PB: buildBatchUserPrompt(command, contexts)
    PB-->>WS: aggregated prompt with [1], [2], ...
    WS->>Claude: execute(prompt, systemPrompt)
    Claude-->>Client: streaming response
```

## Test plan
- [x] Unit tests for `buildBatchUserPrompt` covering fix, explain, validate, custom commands
- [x] Error cases: empty contexts array, missing customPrompt, unsupported commands
- [ ] Frontend integration (follow-up PR)