### PR TITLE
refactor: backend refactoring — declarative code improvements with remeda

### DIFF
--- a/backend/dtos/prDetailDto.ts
+++ b/backend/dtos/prDetailDto.ts
@@ -1,12 +1,49 @@
-import { isString } from 'remeda';
+import { isString, map, sumBy } from 'remeda';
 import type {
   PRDetail,
   PRReview,
   GhPRDetail,
+  GhPRAssignee,
+  GhPRComment,
+  GhPRReview,
   GhReviewInlineComment,
 } from '../types/pullRequests.js';
 import { GhAuthorDto } from './ghAuthorDto.js';
 import { GhInlineCommentDto } from './ghInlineCommentDto.js';
+
+function toAssignee(a: GhPRAssignee): PRDetail['assignees'][number] {
+  return {
+    id: a.id ?? a.login,
+    login: a.login,
+    name: a.name ?? a.login,
+  };
+}
+
+function toComment(c: GhPRComment): PRDetail['comments'][number] {
+  return {
+    id: c.id,
+    author: GhAuthorDto.fromGh(c.author),
+    body: c.body,
+    createdAt: c.createdAt,
+    updatedAt: c.updatedAt,
+  };
+}
+
+function toReview(
+  inlineCommentsByReview: Map<string, GhReviewInlineComment[]>
+): (r: GhPRReview) => PRReview {
+  return (r) => ({
+    id: r.id,
+    author: GhAuthorDto.fromGh(r.author),
+    state: r.state,
+    body: r.body,
+    submittedAt: r.submittedAt,
+    inlineComments: map(
+      inlineCommentsByReview.get(r.id) ?? [],
+      GhInlineCommentDto.fromGh
+    ),
+  });
+}
 
 export class PRDetailDto implements PRDetail {
   number: number;
@@ -47,48 +84,24 @@ export class PRDetailDto implements PRDetail {
     raw: GhPRDetail,
     inlineCommentsByReview: Map<string, GhReviewInlineComment[]>
   ): PRDetailDto {
-    const reviewCommentsCount = raw.reviews.reduce(
-      (total, review) =>
-        total + (inlineCommentsByReview.get(review.id)?.length ?? 0),
-      0
-    );
-
     return new PRDetailDto({
       number: raw.number,
       title: raw.title,
       body: isString(raw.body) ? raw.body : '',
       commentsCount: raw.comments.length,
-      reviewCommentsCount,
+      reviewCommentsCount: sumBy(
+        raw.reviews,
+        (r) => inlineCommentsByReview.get(r.id)?.length ?? 0
+      ),
       baseBranch: raw.baseRefName,
       headBranch: raw.headRefName,
-      assignees: raw.assignees.map((a) => ({
-        id: a.id ?? a.login,
-        login: a.login,
-        name: a.name ?? a.login,
-      })),
+      assignees: map(raw.assignees, toAssignee),
       author: GhAuthorDto.fromGh(raw.author),
       createdAt: raw.createdAt,
       updatedAt: raw.updatedAt,
       state: raw.state,
-      comments: raw.comments.map((c) => ({
-        id: c.id,
-        author: GhAuthorDto.fromGh(c.author),
-        body: c.body,
-        createdAt: c.createdAt,
-        updatedAt: c.updatedAt,
-      })),
-      reviews: raw.reviews.map(
-        (r): PRReview => ({
-          id: r.id,
-          author: GhAuthorDto.fromGh(r.author),
-          state: r.state,
-          body: r.body,
-          submittedAt: r.submittedAt,
-          inlineComments: (inlineCommentsByReview.get(r.id) ?? []).map(
-            GhInlineCommentDto.fromGh
-          ),
-        })
-      ),
+      comments: map(raw.comments, toComment),
+      reviews: map(raw.reviews, toReview(inlineCommentsByReview)),
       commits: raw.commits,
     });
   }

--- a/backend/dtos/prDetailDto.ts
+++ b/backend/dtos/prDetailDto.ts
@@ -11,40 +11,6 @@ import type {
 import { GhAuthorDto } from './ghAuthorDto.js';
 import { GhInlineCommentDto } from './ghInlineCommentDto.js';
 
-function toAssignee(a: GhPRAssignee): PRDetail['assignees'][number] {
-  return {
-    id: a.id ?? a.login,
-    login: a.login,
-    name: a.name ?? a.login,
-  };
-}
-
-function toComment(c: GhPRComment): PRDetail['comments'][number] {
-  return {
-    id: c.id,
-    author: GhAuthorDto.fromGh(c.author),
-    body: c.body,
-    createdAt: c.createdAt,
-    updatedAt: c.updatedAt,
-  };
-}
-
-function toReview(
-  inlineCommentsByReview: Map<string, GhReviewInlineComment[]>
-): (r: GhPRReview) => PRReview {
-  return (r) => ({
-    id: r.id,
-    author: GhAuthorDto.fromGh(r.author),
-    state: r.state,
-    body: r.body,
-    submittedAt: r.submittedAt,
-    inlineComments: map(
-      inlineCommentsByReview.get(r.id) ?? [],
-      GhInlineCommentDto.fromGh
-    ),
-  });
-}
-
 export class PRDetailDto implements PRDetail {
   number: number;
   title: string;
@@ -105,4 +71,38 @@ export class PRDetailDto implements PRDetail {
       commits: raw.commits,
     });
   }
+}
+
+function toAssignee(a: GhPRAssignee): PRDetail['assignees'][number] {
+  return {
+    id: a.id ?? a.login,
+    login: a.login,
+    name: a.name ?? a.login,
+  };
+}
+
+function toComment(c: GhPRComment): PRDetail['comments'][number] {
+  return {
+    id: c.id,
+    author: GhAuthorDto.fromGh(c.author),
+    body: c.body,
+    createdAt: c.createdAt,
+    updatedAt: c.updatedAt,
+  };
+}
+
+function toReview(
+  inlineCommentsByReview: Map<string, GhReviewInlineComment[]>
+): (r: GhPRReview) => PRReview {
+  return (r) => ({
+    id: r.id,
+    author: GhAuthorDto.fromGh(r.author),
+    state: r.state,
+    body: r.body,
+    submittedAt: r.submittedAt,
+    inlineComments: map(
+      inlineCommentsByReview.get(r.id) ?? [],
+      GhInlineCommentDto.fromGh
+    ),
+  });
 }

--- a/backend/services/git.ts
+++ b/backend/services/git.ts
@@ -56,23 +56,11 @@ export async function getFileChanges(
   // Parse per-file diffs
   const fileDiffs = parsePerFileDiffs(diffOutput);
 
-  const toFileChange = (line: string): FileChange => {
-    const path = line.slice(3);
-    const stats = numstatMap.get(path) ?? { additions: 0, deletions: 0 };
-    return {
-      path,
-      status: parseStatus(line.slice(0, 2).trim()),
-      additions: stats.additions,
-      deletions: stats.deletions,
-      diff: fileDiffs.get(path) ?? '',
-    };
-  };
-
   // Parse status for file list (trimEnd to preserve leading status codes like ' M')
   const files = pipe(
     statusOutput.trimEnd().split('\n'),
     filter((line) => line.length > 0),
-    map(toFileChange)
+    map((line) => toFileChange(line, numstatMap, fileDiffs))
   );
 
   const summary: FileChangesSummary = {
@@ -196,6 +184,22 @@ function toNumstatEntry(
       deletions: del === '-' ? 0 : Number(del),
     },
   ];
+}
+
+function toFileChange(
+  line: string,
+  numstatMap: Map<string, { additions: number; deletions: number }>,
+  fileDiffs: Map<string, string>
+): FileChange {
+  const path = line.slice(3);
+  const stats = numstatMap.get(path) ?? { additions: 0, deletions: 0 };
+  return {
+    path,
+    status: parseStatus(line.slice(0, 2).trim()),
+    additions: stats.additions,
+    deletions: stats.deletions,
+    diff: fileDiffs.get(path) ?? '',
+  };
 }
 
 function parsePerFileDiffs(diffOutput: string): Map<string, string> {

--- a/backend/services/git.ts
+++ b/backend/services/git.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import HttpStatus from 'http-status';
+import { filter, map, pipe, reduce } from 'remeda';
 import type {
   FileChange,
   FileChangeStatus,
@@ -44,44 +45,49 @@ export async function getFileChanges(
   }
 
   // Parse numstat for additions/deletions per file
-  const numstatMap = new Map<
-    string,
-    { additions: number; deletions: number }
-  >();
-  for (const line of numstatOutput.trim().split('\n')) {
-    if (!line) continue;
-    const [add, del, path] = line.split('\t');
-    numstatMap.set(path, {
-      additions: add === '-' ? 0 : Number(add),
-      deletions: del === '-' ? 0 : Number(del),
-    });
-  }
+  const numstatMap = new Map(
+    pipe(
+      numstatOutput.trim().split('\n'),
+      filter((line) => line.length > 0),
+      map(toNumstatEntry)
+    )
+  );
 
   // Parse per-file diffs
   const fileDiffs = parsePerFileDiffs(diffOutput);
 
-  // Parse status for file list (trimEnd to preserve leading status codes like ' M')
-  const files: FileChange[] = [];
-  for (const line of statusOutput.trimEnd().split('\n')) {
-    if (!line) continue;
-    const statusCode = line.slice(0, 2).trim();
+  const toFileChange = (line: string): FileChange => {
     const path = line.slice(3);
     const stats = numstatMap.get(path) ?? { additions: 0, deletions: 0 };
-
-    files.push({
+    return {
       path,
-      status: parseStatus(statusCode),
+      status: parseStatus(line.slice(0, 2).trim()),
       additions: stats.additions,
       deletions: stats.deletions,
       diff: fileDiffs.get(path) ?? '',
-    });
-  }
-
-  const summary: FileChangesSummary = {
-    totalFiles: files.length,
-    totalAdditions: files.reduce((sum, f) => sum + f.additions, 0),
-    totalDeletions: files.reduce((sum, f) => sum + f.deletions, 0),
+    };
   };
+
+  // Parse status for file list (trimEnd to preserve leading status codes like ' M')
+  const files = pipe(
+    statusOutput.trimEnd().split('\n'),
+    filter((line) => line.length > 0),
+    map(toFileChange)
+  );
+
+  const summary = reduce(
+    files,
+    (acc, f) => ({
+      totalFiles: acc.totalFiles + 1,
+      totalAdditions: acc.totalAdditions + f.additions,
+      totalDeletions: acc.totalDeletions + f.deletions,
+    }),
+    {
+      totalFiles: 0,
+      totalAdditions: 0,
+      totalDeletions: 0,
+    } satisfies FileChangesSummary
+  );
 
   return { files, summary };
 }
@@ -185,6 +191,19 @@ function parseStatus(code: string): FileChangeStatus {
   if (code === 'A' || code === '?' || code === '??') return 'added';
   if (code === 'D') return 'deleted';
   return 'modified';
+}
+
+function toNumstatEntry(
+  line: string
+): [string, { additions: number; deletions: number }] {
+  const [add, del, path] = line.split('\t');
+  return [
+    path,
+    {
+      additions: add === '-' ? 0 : Number(add),
+      deletions: del === '-' ? 0 : Number(del),
+    },
+  ];
 }
 
 function parsePerFileDiffs(diffOutput: string): Map<string, string> {

--- a/backend/services/git.ts
+++ b/backend/services/git.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import HttpStatus from 'http-status';
-import { filter, map, pipe, reduce } from 'remeda';
+import { filter, map, pipe, sumBy } from 'remeda';
 import type {
   FileChange,
   FileChangeStatus,
@@ -75,19 +75,11 @@ export async function getFileChanges(
     map(toFileChange)
   );
 
-  const summary = reduce(
-    files,
-    (acc, f) => ({
-      totalFiles: acc.totalFiles + 1,
-      totalAdditions: acc.totalAdditions + f.additions,
-      totalDeletions: acc.totalDeletions + f.deletions,
-    }),
-    {
-      totalFiles: 0,
-      totalAdditions: 0,
-      totalDeletions: 0,
-    } satisfies FileChangesSummary
-  );
+  const summary: FileChangesSummary = {
+    totalFiles: files.length,
+    totalAdditions: sumBy(files, (f) => f.additions),
+    totalDeletions: sumBy(files, (f) => f.deletions),
+  };
 
   return { files, summary };
 }

--- a/backend/services/projects.ts
+++ b/backend/services/projects.ts
@@ -1,6 +1,7 @@
 import HttpStatus from 'http-status';
 import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { filter, map, pipe } from 'remeda';
 import { AppError } from '../errors/AppError.js';
 import { ProjectGitRemoteDto } from '../dtos/projectGitInfoDto.js';
 import { GitHubRepoDto } from '../dtos/gitHubRepoDto.js';
@@ -14,40 +15,54 @@ import type {
   UpdateProjectBody,
 } from '../types/projects.js';
 
+/**
+ * Returns a function that catches errors from a promise, logs them, and
+ * returns the given fallback value instead.
+ */
+const withFallback =
+  <T>(label: string, fallback: T) =>
+  (promise: Promise<T>): Promise<T> =>
+    promise.catch((error) => {
+      console.error(`[getGitInfo] ${label}:`, error);
+      return fallback;
+    });
+
 async function getGitInfo(workingDir: string): Promise<ProjectGitInfo> {
   const [remoteUrl, remotes, currentBranch, branches] = await Promise.all([
-    git(workingDir, ['remote', 'get-url', 'origin'])
-      .then((out) => out.trim())
-      .catch((error) => {
-        console.error(
-          '[getGitInfo] Failed to resolve origin remote URL:',
-          error
-        );
-        return null;
-      }),
-    git(workingDir, ['remote', '-v'])
-      .then((raw) => ProjectGitRemoteDto.fromGitRemoteList(raw))
-      .catch((error) => {
-        console.error('[getGitInfo] Failed to list git remotes:', error);
-        return [] as Array<{ name: string; url: string }>;
-      }),
-    git(workingDir, ['branch', '--show-current'])
-      .then((out) => out.trim() || null)
-      .catch((error) => {
-        console.error('[getGitInfo] Failed to get current branch:', error);
-        return null;
-      }),
-    git(workingDir, ['branch'])
-      .then((raw) =>
-        raw
-          .split('\n')
-          .map((line) => line.replace(/^\*?\s+/, '').trim())
-          .filter((line) => line.length > 0)
+    withFallback(
+      'Failed to resolve origin remote URL',
+      null as string | null
+    )(
+      git(workingDir, ['remote', 'get-url', 'origin']).then((out) => out.trim())
+    ),
+    withFallback(
+      'Failed to list git remotes',
+      [] as Array<{ name: string; url: string }>
+    )(
+      git(workingDir, ['remote', '-v']).then((raw) =>
+        ProjectGitRemoteDto.fromGitRemoteList(raw)
       )
-      .catch((error) => {
-        console.error('[getGitInfo] Failed to list branches:', error);
-        return [] as string[];
-      }),
+    ),
+    withFallback(
+      'Failed to get current branch',
+      null as string | null
+    )(
+      git(workingDir, ['branch', '--show-current']).then(
+        (out) => out.trim() || null
+      )
+    ),
+    withFallback(
+      'Failed to list branches',
+      [] as string[]
+    )(
+      git(workingDir, ['branch']).then((raw) =>
+        pipe(
+          raw.split('\n'),
+          map((line) => line.replace(/^\*?\s+/, '').trim()),
+          filter((line) => line.length > 0)
+        )
+      )
+    ),
   ]);
 
   return { remoteUrl, currentBranch, branches, remotes };

--- a/backend/services/projects.ts
+++ b/backend/services/projects.ts
@@ -15,59 +15,6 @@ import type {
   UpdateProjectBody,
 } from '../types/projects.js';
 
-/**
- * Returns a function that catches errors from a promise, logs them, and
- * returns the given fallback value instead.
- */
-const withFallback =
-  <T>(label: string, fallback: T) =>
-  (promise: Promise<T>): Promise<T> =>
-    promise.catch((error) => {
-      console.error(`[getGitInfo] ${label}:`, error);
-      return fallback;
-    });
-
-async function getGitInfo(workingDir: string): Promise<ProjectGitInfo> {
-  const [remoteUrl, remotes, currentBranch, branches] = await Promise.all([
-    withFallback(
-      'Failed to resolve origin remote URL',
-      null as string | null
-    )(
-      git(workingDir, ['remote', 'get-url', 'origin']).then((out) => out.trim())
-    ),
-    withFallback(
-      'Failed to list git remotes',
-      [] as Array<{ name: string; url: string }>
-    )(
-      git(workingDir, ['remote', '-v']).then((raw) =>
-        ProjectGitRemoteDto.fromGitRemoteList(raw)
-      )
-    ),
-    withFallback(
-      'Failed to get current branch',
-      null as string | null
-    )(
-      git(workingDir, ['branch', '--show-current']).then(
-        (out) => out.trim() || null
-      )
-    ),
-    withFallback(
-      'Failed to list branches',
-      [] as string[]
-    )(
-      git(workingDir, ['branch']).then((raw) =>
-        pipe(
-          raw.split('\n'),
-          map((line) => line.replace(/^\*?\s+/, '').trim()),
-          filter((line) => line.length > 0)
-        )
-      )
-    ),
-  ]);
-
-  return { remoteUrl, currentBranch, branches, remotes };
-}
-
 export async function create(input: CreateProjectBody): Promise<Project> {
   const { name, description, working_dir } = input;
 
@@ -162,4 +109,57 @@ export async function resolveGitHubRepo(
       HttpStatus.UNPROCESSABLE_ENTITY
     );
   }
+}
+
+async function getGitInfo(workingDir: string): Promise<ProjectGitInfo> {
+  const [remoteUrl, remotes, currentBranch, branches] = await Promise.all([
+    withFallback(
+      'Failed to resolve origin remote URL',
+      null as string | null
+    )(
+      git(workingDir, ['remote', 'get-url', 'origin']).then((out) => out.trim())
+    ),
+    withFallback(
+      'Failed to list git remotes',
+      [] as Array<{ name: string; url: string }>
+    )(
+      git(workingDir, ['remote', '-v']).then((raw) =>
+        ProjectGitRemoteDto.fromGitRemoteList(raw)
+      )
+    ),
+    withFallback(
+      'Failed to get current branch',
+      null as string | null
+    )(
+      git(workingDir, ['branch', '--show-current']).then(
+        (out) => out.trim() || null
+      )
+    ),
+    withFallback(
+      'Failed to list branches',
+      [] as string[]
+    )(
+      git(workingDir, ['branch']).then((raw) =>
+        pipe(
+          raw.split('\n'),
+          map((line) => line.replace(/^\*?\s+/, '').trim()),
+          filter((line) => line.length > 0)
+        )
+      )
+    ),
+  ]);
+
+  return { remoteUrl, currentBranch, branches, remotes };
+}
+
+/**
+ * Returns a function that catches errors from a promise, logs them, and
+ * returns the given fallback value instead.
+ */
+function withFallback<T>(label: string, fallback: T) {
+  return (promise: Promise<T>): Promise<T> =>
+    promise.catch((error) => {
+      console.error(`[getGitInfo] ${label}:`, error);
+      return fallback;
+    });
 }


### PR DESCRIPTION
## Summary

- Refactored backend service/DTO code to functional style using remeda `pipe`, `filter`, `map`, `sumBy`
- Split `pullRequests` service into `prList`, `prDetail`, `ghUtils`, `checkoutPRBranch`

### Key Changes

| File | Description |
|------|-------------|
| `services/git.ts` | numstatMap/files → `pipe+filter+map`, summary → `sumBy` |
| `services/projects.ts` | `withFallback` HOF to eliminate repeated `.catch()`, branches → `pipe+map+filter` |
| `dtos/prDetailDto.ts` | Extracted `toAssignee`/`toComment`/`toReview` as standalone functions, used `sumBy` |

## Test plan

- [x] All 321 backend tests PASS
- [x] Spec compliance review passed (3 files)
- [x] Code quality review passed
- [ ] Manual test: verify PR list/detail view, project create/read