### PR TITLE
refactor: extract handlers and simplify dispatch patterns in Claude backend

### DIFF
--- a/backend/controllers/ClaudeWSController.ts
+++ b/backend/controllers/ClaudeWSController.ts
@@ -9,6 +9,10 @@ import type {
   WsClientMessage,
   WsCommandExecuteMessage,
   WsBatchExecuteMessage,
+  WsFollowUpExecuteMessage,
+  WsAbortMessage,
+  WsApprovalResponseMessage,
+  WsPlanApprovalResponseMessage,
 } from '../types/claude.js';
 
 export function handleClaudeWebSocket(ws: WebSocket): void {
@@ -25,145 +29,7 @@ export function handleClaudeWebSocket(ws: WebSocket): void {
       return;
     }
 
-    if (msg.type === 'abort') {
-      manager.abort(msg.requestId);
-      return;
-    }
-
-    if (msg.type === 'followUp') {
-      manager.execute(
-        msg.requestId,
-        msg.message,
-        msg.workingDir,
-        msg.options,
-        msg.chatContext
-      );
-      return;
-    }
-
-    if (msg.type === 'execute') {
-      const { requestId, workingDir, options, chatContext } = msg;
-
-      const cmdMsg = msg as WsCommandExecuteMessage;
-      let userPrompt: string;
-      let systemPrompt: string;
-      try {
-        systemPrompt = buildSystemPrompt(cmdMsg.context);
-        userPrompt = buildUserPrompt(
-          cmdMsg.command,
-          cmdMsg.context,
-          cmdMsg.customPrompt
-        );
-      } catch (err) {
-        ws.send(
-          JSON.stringify({
-            type: 'error',
-            requestId,
-            message:
-              err instanceof Error ? err.message : 'Failed to build prompt',
-          })
-        );
-        return;
-      }
-
-      manager.execute(
-        requestId,
-        userPrompt,
-        workingDir,
-        options,
-        chatContext,
-        {
-          command: cmdMsg.command,
-          customPrompt: cmdMsg.customPrompt,
-        },
-        systemPrompt
-      );
-      return;
-    }
-
-    if (msg.type === 'approval_response') {
-      const { requestId, approvalRequestId, behavior, message, updatedInput } =
-        msg;
-      manager.respondToToolApproval(
-        requestId,
-        approvalRequestId,
-        behavior,
-        message,
-        updatedInput
-      );
-      return;
-    }
-
-    if (msg.type === 'plan_approval_response') {
-      const { requestId, approvalRequestId, behavior, message, updatedInput } =
-        msg;
-      manager.respondToPlanApproval(
-        requestId,
-        approvalRequestId,
-        behavior,
-        message,
-        updatedInput
-      );
-      return;
-    }
-
-    if (msg.type === 'batchExecute') {
-      const {
-        requestId,
-        workingDir,
-        options,
-        chatContext,
-        command,
-        contexts,
-        customPrompt,
-      } = msg as WsBatchExecuteMessage;
-
-      if (!contexts || contexts.length === 0) {
-        ws.send(
-          JSON.stringify({
-            type: 'error',
-            requestId,
-            message: 'contexts must be a non-empty array',
-          })
-        );
-        return;
-      }
-
-      let userPrompt: string;
-      let systemPrompt: string;
-      try {
-        systemPrompt = buildSystemPrompt(contexts[0]);
-        userPrompt = buildBatchUserPrompt(command, contexts, customPrompt);
-      } catch (err) {
-        ws.send(
-          JSON.stringify({
-            type: 'error',
-            requestId,
-            message:
-              err instanceof Error ? err.message : 'Failed to build prompt',
-          })
-        );
-        return;
-      }
-
-      manager.execute(
-        requestId,
-        userPrompt,
-        workingDir,
-        options,
-        chatContext,
-        { command, customPrompt },
-        systemPrompt
-      );
-      return;
-    }
-
-    ws.send(
-      JSON.stringify({
-        type: 'error',
-        message: `Unknown message type: ${(msg as { type: string }).type}`,
-      })
-    );
+    routeMessage(msg, manager, ws);
   });
 
   ws.on('close', () => {
@@ -174,4 +40,166 @@ export function handleClaudeWebSocket(ws: WebSocket): void {
     console.error('[WS] Connection error:', err.message);
     manager.abortAll();
   });
+}
+
+function routeMessage(
+  msg: WsClientMessage,
+  manager: ClaudeSessionManager,
+  ws: WebSocket
+): void {
+  switch (msg.type) {
+    case 'execute':
+      return handleExecute(msg, manager, ws);
+    case 'batchExecute':
+      return handleBatchExecute(msg, manager, ws);
+    case 'followUp':
+      return handleFollowUp(msg, manager);
+    case 'abort':
+      return handleAbort(msg, manager);
+    case 'approval_response':
+      return handleApprovalResponse(msg, manager);
+    case 'plan_approval_response':
+      return handlePlanApprovalResponse(msg, manager);
+    default: {
+      msg satisfies never;
+      ws.send(
+        JSON.stringify({
+          type: 'error',
+          message: `Unknown message type: ${(msg as { type: string }).type}`,
+        })
+      );
+    }
+  }
+}
+
+function handleExecute(
+  msg: WsCommandExecuteMessage,
+  manager: ClaudeSessionManager,
+  ws: WebSocket
+): void {
+  const { requestId, workingDir, options, chatContext } = msg;
+
+  let userPrompt: string;
+  let systemPrompt: string;
+  try {
+    systemPrompt = buildSystemPrompt(msg.context);
+    userPrompt = buildUserPrompt(msg.command, msg.context, msg.customPrompt);
+  } catch (err) {
+    sendError(ws, requestId, err);
+    return;
+  }
+
+  manager.execute({
+    requestId,
+    prompt: userPrompt,
+    workingDir,
+    options,
+    chatContext,
+    commandMeta: { command: msg.command, customPrompt: msg.customPrompt },
+    systemPrompt,
+  });
+}
+
+function handleBatchExecute(
+  msg: WsBatchExecuteMessage,
+  manager: ClaudeSessionManager,
+  ws: WebSocket
+): void {
+  const {
+    requestId,
+    workingDir,
+    options,
+    chatContext,
+    command,
+    contexts,
+    customPrompt,
+  } = msg;
+
+  if (!contexts || contexts.length === 0) {
+    ws.send(
+      JSON.stringify({
+        type: 'error',
+        requestId,
+        message: 'contexts must be a non-empty array',
+      })
+    );
+    return;
+  }
+
+  let userPrompt: string;
+  let systemPrompt: string;
+  try {
+    systemPrompt = buildSystemPrompt(contexts[0]);
+    userPrompt = buildBatchUserPrompt(command, contexts, customPrompt);
+  } catch (err) {
+    sendError(ws, requestId, err);
+    return;
+  }
+
+  manager.execute({
+    requestId,
+    prompt: userPrompt,
+    workingDir,
+    options,
+    chatContext,
+    commandMeta: { command, customPrompt },
+    systemPrompt,
+  });
+}
+
+function handleFollowUp(
+  msg: WsFollowUpExecuteMessage,
+  manager: ClaudeSessionManager
+): void {
+  manager.execute({
+    requestId: msg.requestId,
+    prompt: msg.message,
+    workingDir: msg.workingDir,
+    options: msg.options,
+    chatContext: msg.chatContext,
+  });
+}
+
+function handleAbort(msg: WsAbortMessage, manager: ClaudeSessionManager): void {
+  manager.abort(msg.requestId);
+}
+
+function handleApprovalResponse(
+  msg: WsApprovalResponseMessage,
+  manager: ClaudeSessionManager
+): void {
+  manager.respondToToolApproval(
+    msg.requestId,
+    msg.approvalRequestId,
+    msg.behavior,
+    msg.message,
+    msg.updatedInput
+  );
+}
+
+function handlePlanApprovalResponse(
+  msg: WsPlanApprovalResponseMessage,
+  manager: ClaudeSessionManager
+): void {
+  manager.respondToPlanApproval(
+    msg.requestId,
+    msg.approvalRequestId,
+    msg.behavior,
+    msg.message,
+    msg.updatedInput
+  );
+}
+
+function sendError(
+  ws: WebSocket,
+  requestId: string | undefined,
+  err: unknown
+): void {
+  ws.send(
+    JSON.stringify({
+      type: 'error',
+      requestId,
+      message: err instanceof Error ? err.message : 'Failed to build prompt',
+    })
+  );
 }

--- a/backend/services/claude/ClaudeProcess.ts
+++ b/backend/services/claude/ClaudeProcess.ts
@@ -51,6 +51,21 @@ export class ClaudeProcess extends EventEmitter<ClaudeStreamEvents> {
   private errored = false;
   private resultReceived = false;
 
+  private static readonly HOOKS_BY_MODE: Record<
+    string,
+    { matcher: string; hookCallbackIds: string[] }[]
+  > = {
+    plan: [{ matcher: '*', hookCallbackIds: ['auto_approve'] }],
+    acceptEdits: [{ matcher: '^Bash$', hookCallbackIds: ['tool_approval'] }],
+    bypassPermissions: [],
+    default: [
+      {
+        matcher: '^(?!(Glob|Grep|Read|Task|TodoWrite)$).*',
+        hookCallbackIds: ['tool_approval'],
+      },
+    ],
+  };
+
   constructor(
     workingDir: string,
     options: ClaudeExecuteOptions = {},
@@ -96,37 +111,9 @@ export class ClaudeProcess extends EventEmitter<ClaudeStreamEvents> {
   }
 
   sendInitialize(requestId: string, mode?: string): void {
-    let preToolUseHooks: { matcher: string; hookCallbackIds: string[] }[];
-    switch (mode) {
-      case 'plan':
-        preToolUseHooks = [
-          {
-            matcher: '*',
-            hookCallbackIds: ['auto_approve'],
-          },
-        ];
-        break;
-      case 'acceptEdits':
-        preToolUseHooks = [
-          {
-            matcher: '^Bash$',
-            hookCallbackIds: ['tool_approval'],
-          },
-        ];
-        break;
-      case 'bypassPermissions':
-        preToolUseHooks = [];
-        break;
-      case 'default':
-      default:
-        preToolUseHooks = [
-          {
-            matcher: '^(?!(Glob|Grep|Read|Task|TodoWrite)$).*',
-            hookCallbackIds: ['tool_approval'],
-          },
-        ];
-        break;
-    }
+    const preToolUseHooks =
+      ClaudeProcess.HOOKS_BY_MODE[mode ?? 'default'] ??
+      ClaudeProcess.HOOKS_BY_MODE['default'];
 
     this.writeJson({
       type: 'control_request',
@@ -217,12 +204,12 @@ export class ClaudeProcess extends EventEmitter<ClaudeStreamEvents> {
     });
   }
 
-  private writeJson(value: unknown): void {
-    this.childProcess?.stdin!.write(JSON.stringify(value) + '\n');
-  }
-
   abort(): void {
     this.childProcess?.kill();
+  }
+
+  private writeJson(value: unknown): void {
+    this.childProcess?.stdin!.write(JSON.stringify(value) + '\n');
   }
 
   private handleChunk(chunk: Buffer): void {

--- a/backend/services/claude/ClaudeSessionManager.test.ts
+++ b/backend/services/claude/ClaudeSessionManager.test.ts
@@ -50,21 +50,19 @@ describe('ClaudeSessionManager', () => {
   it('persists a chat session when a new claude execution initializes with session id', async () => {
     const manager = new ClaudeSessionManager(ws as never);
 
-    manager.execute(
-      'request-1',
-      'prompt',
-      '/tmp/project',
-      {
-        executionMode: 'default',
-      },
-      {
+    manager.execute({
+      requestId: 'request-1',
+      prompt: 'prompt',
+      workingDir: '/tmp/project',
+      options: { executionMode: 'default' },
+      chatContext: {
         projectId: 'project-1',
         prNumber: 45,
         scopeType: 'REVIEW',
         scopeTargetId: 'review-123',
         title: 'Validate review',
-      }
-    );
+      },
+    });
 
     const proc = processInstances[0];
     expect(proc).toBeDefined();
@@ -87,14 +85,19 @@ describe('ClaudeSessionManager', () => {
 
   it('passes commandMeta to createChatSessionFromExecution when provided', async () => {
     const manager = new ClaudeSessionManager(ws as never);
-    manager.execute(
-      'request-meta',
-      'some prompt',
-      '/tmp/project',
-      { executionMode: 'default' },
-      { projectId: 'p', prNumber: 1, scopeType: 'REVIEW', scopeTargetId: 'r' },
-      { command: 'validate', customPrompt: undefined }
-    );
+    manager.execute({
+      requestId: 'request-meta',
+      prompt: 'some prompt',
+      workingDir: '/tmp/project',
+      options: { executionMode: 'default' },
+      chatContext: {
+        projectId: 'p',
+        prNumber: 1,
+        scopeType: 'REVIEW',
+        scopeTargetId: 'r',
+      },
+      commandMeta: { command: 'validate', customPrompt: undefined },
+    });
     processInstances[0]!.emit('init', 'claude-session-meta');
     await Promise.resolve();
     expect(mockCreateChatSessionFromExecution).toHaveBeenCalledWith(
@@ -107,19 +110,19 @@ describe('ClaudeSessionManager', () => {
   it('does not persist a new chat session on done without init', async () => {
     const manager = new ClaudeSessionManager(ws as never);
 
-    manager.execute(
-      'request-4',
-      'prompt',
-      '/tmp/project',
-      { executionMode: 'default' },
-      {
+    manager.execute({
+      requestId: 'request-4',
+      prompt: 'prompt',
+      workingDir: '/tmp/project',
+      options: { executionMode: 'default' },
+      chatContext: {
         projectId: 'project-1',
         prNumber: 45,
         scopeType: 'REVIEW',
         scopeTargetId: 'review-456',
         title: 'Done should not persist',
-      }
-    );
+      },
+    });
 
     const proc = processInstances[0];
     expect(proc).toBeDefined();
@@ -133,9 +136,14 @@ describe('ClaudeSessionManager', () => {
   it('touches an existing chat session when resuming with a claude session id', () => {
     const manager = new ClaudeSessionManager(ws as never);
 
-    manager.execute('request-2', 'prompt', '/tmp/project', {
-      executionMode: 'default',
-      sessionId: 'claude-session-1',
+    manager.execute({
+      requestId: 'request-2',
+      prompt: 'prompt',
+      workingDir: '/tmp/project',
+      options: {
+        executionMode: 'default',
+        sessionId: 'claude-session-1',
+      },
     });
 
     expect(mockMarkChatSessionAsUsed).toHaveBeenCalledWith('claude-session-1');
@@ -144,15 +152,13 @@ describe('ClaudeSessionManager', () => {
 
   it('passes systemPrompt to ClaudeProcess when provided', () => {
     const manager = new ClaudeSessionManager(ws as never);
-    manager.execute(
-      'request-sp',
-      'some prompt',
-      '/tmp/project',
-      { executionMode: 'default' },
-      undefined,
-      undefined,
-      'You are a code review assistant.'
-    );
+    manager.execute({
+      requestId: 'request-sp',
+      prompt: 'some prompt',
+      workingDir: '/tmp/project',
+      options: { executionMode: 'default' },
+      systemPrompt: 'You are a code review assistant.',
+    });
 
     const proc = processInstances[0];
     expect(proc).toBeDefined();
@@ -161,7 +167,11 @@ describe('ClaudeSessionManager', () => {
 
   it('leaves systemPrompt undefined when not provided', () => {
     const manager = new ClaudeSessionManager(ws as never);
-    manager.execute('request-no-sp', 'prompt', '/tmp/project');
+    manager.execute({
+      requestId: 'request-no-sp',
+      prompt: 'prompt',
+      workingDir: '/tmp/project',
+    });
 
     const proc = processInstances[0];
     expect(proc!.systemPrompt).toBeUndefined();
@@ -170,8 +180,11 @@ describe('ClaudeSessionManager', () => {
   it('forwards init events from the claude process to websocket', () => {
     const manager = new ClaudeSessionManager(ws as never);
 
-    manager.execute('request-3', 'prompt', '/tmp/project', {
-      executionMode: 'default',
+    manager.execute({
+      requestId: 'request-3',
+      prompt: 'prompt',
+      workingDir: '/tmp/project',
+      options: { executionMode: 'default' },
     });
 
     const proc = processInstances[0];

--- a/backend/services/claude/ClaudeSessionManager.ts
+++ b/backend/services/claude/ClaudeSessionManager.ts
@@ -9,6 +9,16 @@ import {
 } from '../chatSessions.js';
 import { getFileChanges } from '../git.js';
 
+export interface ExecuteParams {
+  requestId: string;
+  prompt: string;
+  workingDir: string;
+  options?: ClaudeExecuteOptions;
+  chatContext?: ClaudeChatContext;
+  commandMeta?: { command?: string; customPrompt?: string };
+  systemPrompt?: string;
+}
+
 export class ClaudeSessionManager {
   private processes = new Map<string, ClaudeProcess>();
   private sender: WebSocketSender;
@@ -17,16 +27,18 @@ export class ClaudeSessionManager {
     this.sender = new WebSocketSender(ws);
   }
 
-  execute(
-    requestId: string,
-    prompt: string,
-    workingDir: string,
-    options: ClaudeExecuteOptions = {},
-    chatContext?: ClaudeChatContext,
-    commandMeta?: { command?: string; customPrompt?: string },
-    systemPrompt?: string
-  ): void {
+  execute(params: ExecuteParams): void {
+    const {
+      requestId,
+      prompt,
+      workingDir,
+      options = {},
+      chatContext,
+      commandMeta,
+      systemPrompt,
+    } = params;
     const { sender } = this;
+
     if (this.processes.has(requestId)) {
       sender.send({
         type: 'error',
@@ -56,6 +68,77 @@ export class ClaudeSessionManager {
         );
       });
     }
+
+    this.attachEventForwarding(proc, requestId, workingDir, {
+      options,
+      chatContext,
+      commandMeta,
+    });
+
+    proc.sendInitialize(requestId, options.executionMode);
+    proc.sendPermissionMode(options.executionMode ?? 'default');
+    proc.sendPrompt(prompt);
+  }
+
+  respondToToolApproval(
+    requestId: string,
+    approvalRequestId: string,
+    behavior: 'allow' | 'deny',
+    message?: string,
+    updatedInput?: unknown
+  ): void {
+    const proc = this.processes.get(requestId);
+    if (!proc) return;
+
+    proc.sendApprovalResponse(
+      approvalRequestId,
+      behavior,
+      message,
+      updatedInput
+    );
+  }
+
+  respondToPlanApproval(
+    requestId: string,
+    approvalRequestId: string,
+    behavior: 'allow' | 'deny',
+    message?: string,
+    updatedInput?: unknown
+  ): void {
+    const proc = this.processes.get(requestId);
+    if (!proc) return;
+
+    proc.sendPlanApprovalResponse(
+      approvalRequestId,
+      behavior,
+      message,
+      updatedInput
+    );
+  }
+
+  abort(requestId: string): void {
+    this.processes.get(requestId)?.abort();
+  }
+
+  abortAll(): void {
+    for (const proc of this.processes.values()) {
+      proc.abort();
+    }
+    this.processes.clear();
+  }
+
+  private attachEventForwarding(
+    proc: ClaudeProcess,
+    requestId: string,
+    workingDir: string,
+    context: {
+      options: ClaudeExecuteOptions;
+      chatContext?: ClaudeChatContext;
+      commandMeta?: { command?: string; customPrompt?: string };
+    }
+  ): void {
+    const { sender } = this;
+    const { options, chatContext, commandMeta } = context;
 
     proc.on('text', (chunk) => sender.send({ type: 'text', requestId, chunk }));
     proc.on('tool_message', (toolId, toolName, input) =>
@@ -134,56 +217,5 @@ export class ClaudeSessionManager {
       sender.send({ type: 'error', requestId, message });
       this.processes.delete(requestId);
     });
-
-    proc.sendInitialize(requestId, options.executionMode);
-    proc.sendPermissionMode(options.executionMode ?? 'default');
-    proc.sendPrompt(prompt);
-  }
-
-  respondToToolApproval(
-    requestId: string,
-    approvalRequestId: string,
-    behavior: 'allow' | 'deny',
-    message?: string,
-    updatedInput?: unknown
-  ): void {
-    const proc = this.processes.get(requestId);
-    if (!proc) return;
-
-    proc.sendApprovalResponse(
-      approvalRequestId,
-      behavior,
-      message,
-      updatedInput
-    );
-  }
-
-  respondToPlanApproval(
-    requestId: string,
-    approvalRequestId: string,
-    behavior: 'allow' | 'deny',
-    message?: string,
-    updatedInput?: unknown
-  ): void {
-    const proc = this.processes.get(requestId);
-    if (!proc) return;
-
-    proc.sendPlanApprovalResponse(
-      approvalRequestId,
-      behavior,
-      message,
-      updatedInput
-    );
-  }
-
-  abort(requestId: string): void {
-    this.processes.get(requestId)?.abort();
-  }
-
-  abortAll(): void {
-    for (const proc of this.processes.values()) {
-      proc.abort();
-    }
-    this.processes.clear();
   }
 }

--- a/backend/services/claude/claudeSessionHistory.ts
+++ b/backend/services/claude/claudeSessionHistory.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import HttpStatus from 'http-status';
+import { filter, map, pipe } from 'remeda';
 import { AppError } from '../../errors/AppError.js';
 import type { ChatSessionHistoryEntry } from '../../types/chatSessions.js';
 
@@ -18,45 +19,6 @@ type TranscriptLine = {
     content?: string | Array<Record<string, unknown>>;
   };
 };
-
-function toProjectTranscriptDir(workingDir: string): string {
-  return workingDir.replace(/[\\/]/g, '-');
-}
-
-function normalizeContent(
-  content: string | Array<Record<string, unknown>> | undefined
-): string {
-  if (typeof content === 'string') {
-    return content.trim();
-  }
-
-  if (!Array.isArray(content)) {
-    return '';
-  }
-
-  return content
-    .map((block) => {
-      if (block.type === 'text' && typeof block.text === 'string') {
-        return block.text.trim();
-      }
-
-      if (block.type === 'tool_use' && typeof block.name === 'string') {
-        return `[tool:${block.name}] ${JSON.stringify(block.input ?? {})}`;
-      }
-
-      if (block.type === 'tool_result') {
-        if (typeof block.content === 'string') {
-          return `[tool_result] ${block.content.trim()}`;
-        }
-        return `[tool_result] ${JSON.stringify(block.content ?? '')}`;
-      }
-
-      return '';
-    })
-    .filter(Boolean)
-    .join('\n')
-    .trim();
-}
 
 const defaultTranscriptsRoot = path.join(os.homedir(), '.claude', 'projects');
 
@@ -121,21 +83,64 @@ export async function getClaudeSessionHistory({
     );
   }
 
-  const rawEntries = raw
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => JSON.parse(line) as TranscriptLine)
-    .filter((line) => line.type === 'user' || line.type === 'assistant')
-    .map((line) => ({
-      role: line.message?.role ?? line.type ?? 'unknown',
+  const rawEntries = pipe(
+    raw.split('\n'),
+    map((line) => line.trim()),
+    filter((line) => line.length > 0),
+    map((line) => JSON.parse(line) as TranscriptLine),
+    filter(
+      (line): line is TranscriptLine & { type: string } =>
+        line.type === 'user' || line.type === 'assistant'
+    ),
+    map((line) => ({
+      role: line.message?.role ?? line.type,
       content: normalizeContent(line.message?.content),
       timestamp: line.timestamp,
-    }))
-    .filter((entry) => entry.content.length > 0);
+    })),
+    filter((entry) => entry.content.length > 0)
+  );
 
   return {
     claudeSessionId,
     entries: replaceFirstUserMessage(rawEntries, command, customPrompt),
   };
+}
+
+function toProjectTranscriptDir(workingDir: string): string {
+  return workingDir.replace(/[\\/]/g, '-');
+}
+
+function normalizeContent(
+  content: string | Array<Record<string, unknown>> | undefined
+): string {
+  if (typeof content === 'string') {
+    return content.trim();
+  }
+
+  if (!Array.isArray(content)) {
+    return '';
+  }
+
+  return content
+    .map((block) => {
+      if (block.type === 'text' && typeof block.text === 'string') {
+        return block.text.trim();
+      }
+
+      if (block.type === 'tool_use' && typeof block.name === 'string') {
+        return `[tool:${block.name}] ${JSON.stringify(block.input ?? {})}`;
+      }
+
+      if (block.type === 'tool_result') {
+        if (typeof block.content === 'string') {
+          return `[tool_result] ${block.content.trim()}`;
+        }
+        return `[tool_result] ${JSON.stringify(block.content ?? '')}`;
+      }
+
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n')
+    .trim();
 }

--- a/backend/services/claude/streamJsonParser.ts
+++ b/backend/services/claude/streamJsonParser.ts
@@ -2,13 +2,6 @@
  * Parses a single stream-json line and extracts structured events,
  * or returns null if the line should be skipped.
  *
- * Real-time text tokens arrive as:
- *   {"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"..."}}}
- *
- * Tool call events:
- *   tool_start  – stream_event > content_block_start with content_block.type === 'tool_use'
- *   tool_complete – assistant message with content[].type === 'tool_use'
- *   tool_result – user message with content[].type === 'tool_result'
  */
 
 export type ParsedStreamEvent =
@@ -39,118 +32,143 @@ export type ParsedStreamEvent =
       input: unknown;
     };
 
+type Parsed = Record<string, unknown>;
+
 export function parseStreamJsonLine(line: string): ParsedStreamEvent | null {
   if (!line.trim()) return null;
 
-  let parsed: Record<string, unknown>;
+  let parsed: Parsed;
   try {
-    parsed = JSON.parse(line) as Record<string, unknown>;
+    parsed = JSON.parse(line) as Parsed;
   } catch {
-    // Not valid JSON – forward as-is (e.g. early diagnostic output)
     return { kind: 'text', text: line };
   }
 
-  if (parsed['type'] === 'stream_event') {
-    const event = parsed['event'] as Record<string, unknown> | undefined;
+  switch (parsed['type']) {
+    case 'stream_event':
+      return parseStreamEvent(parsed);
+    case 'assistant':
+      return parseAssistantMessage(parsed);
+    case 'user':
+      return parseUserMessage(parsed);
+    case 'result':
+      return parseResultMessage(parsed);
+    case 'control_request':
+      return parseControlRequest(parsed);
+    case 'system':
+      return parseInitMessage(parsed);
+    default:
+      return null;
+  }
+}
 
-    // Real-time token streaming: stream_event > content_block_delta > text_delta
-    if (event?.['type'] === 'content_block_delta') {
-      const delta = event['delta'] as Record<string, unknown> | undefined;
-      if (delta?.['type'] === 'text_delta') {
-        const text = delta['text'];
-        return typeof text === 'string' && text ? { kind: 'text', text } : null;
-      }
+function parseStreamEvent(parsed: Parsed): ParsedStreamEvent | null {
+  const event = parsed['event'] as Parsed | undefined;
+
+  if (event?.['type'] === 'content_block_delta') {
+    const delta = event['delta'] as Parsed | undefined;
+    if (delta?.['type'] === 'text_delta') {
+      const text = delta['text'];
+      return typeof text === 'string' && text ? { kind: 'text', text } : null;
     }
+  }
 
-    // Tool call start: stream_event > content_block_start with tool_use block
-    if (event?.['type'] === 'content_block_start') {
-      const block = event['content_block'] as
-        | Record<string, unknown>
-        | undefined;
-      if (block?.['type'] === 'tool_use') {
-        const toolId = block['id'];
-        const toolName = block['name'];
-        if (typeof toolId === 'string' && typeof toolName === 'string') {
-          return { kind: 'tool_start', toolId, toolName };
-        }
+  // Tool call start: stream_event > content_block_start with tool_use block
+  if (event?.['type'] === 'content_block_start') {
+    const block = event['content_block'] as Parsed | undefined;
+    if (block?.['type'] === 'tool_use') {
+      const toolId = block['id'];
+      const toolName = block['name'];
+      if (typeof toolId === 'string' && typeof toolName === 'string') {
+        return { kind: 'tool_start', toolId, toolName };
       }
     }
   }
 
-  // Tool call complete: assistant message containing tool_use content blocks
-  if (parsed['type'] === 'assistant') {
-    const message = parsed['message'] as Record<string, unknown> | undefined;
-    const content = message?.['content'] as unknown[] | undefined;
-    if (Array.isArray(content)) {
-      const toolUse = content.find(
-        (c): c is Record<string, unknown> =>
-          typeof c === 'object' &&
-          c !== null &&
-          (c as Record<string, unknown>)['type'] === 'tool_use'
-      );
-      if (toolUse) {
-        const toolId = toolUse['id'];
-        const toolName = toolUse['name'];
-        const input = toolUse['input'];
-        if (typeof toolId === 'string' && typeof toolName === 'string') {
-          return { kind: 'tool_complete', toolId, toolName, input };
-        }
-      }
-    }
-  }
+  return null;
+}
 
-  // Tool result: user message containing tool_result content blocks
-  if (parsed['type'] === 'user') {
-    const message = parsed['message'] as Record<string, unknown> | undefined;
-    const content = message?.['content'] as unknown[] | undefined;
-    if (Array.isArray(content)) {
-      const toolResult = content.find(
-        (c): c is Record<string, unknown> =>
-          typeof c === 'object' &&
-          c !== null &&
-          (c as Record<string, unknown>)['type'] === 'tool_result'
-      );
-      if (toolResult) {
-        const toolId = toolResult['tool_use_id'];
-        const rawContent = toolResult['content'];
-        const isError = toolResult['is_error'];
-        if (typeof toolId === 'string') {
-          const contentStr =
-            typeof rawContent === 'string'
-              ? rawContent
-              : JSON.stringify(rawContent);
-          return {
-            kind: 'tool_result',
-            toolId,
-            content: contentStr,
-            isError: isError === true,
-          };
-        }
-      }
-    }
-  }
 
-  // Response completion: result message emitted when a turn finishes
-  if (parsed['type'] === 'result') {
-    const result = parsed['result'];
-    const sessionId = parsed['session_id'];
-    const isError = parsed['is_error'];
+/**
+ * Tool call complete: assistant message containing tool_use content blocks
+ */
+function parseAssistantMessage(parsed: Parsed): ParsedStreamEvent | null {
+  const message = parsed['message'] as Parsed | undefined;
+  const content = message?.['content'] as unknown[] | undefined;
+  if (!Array.isArray(content)) return null;
+
+  const toolUse = content.find(
+    (c): c is Parsed =>
+      typeof c === 'object' &&
+      c !== null &&
+      (c as Parsed)['type'] === 'tool_use'
+  );
+  if (!toolUse) return null;
+
+  const toolId = toolUse['id'];
+  const toolName = toolUse['name'];
+  const input = toolUse['input'];
+  if (typeof toolId === 'string' && typeof toolName === 'string') {
+    return { kind: 'tool_complete', toolId, toolName, input };
+  }
+  return null;
+}
+
+/**
+ * Tool result: user message containing tool_result content blocks
+ */
+function parseUserMessage(parsed: Parsed): ParsedStreamEvent | null {
+  const message = parsed['message'] as Parsed | undefined;
+  const content = message?.['content'] as unknown[] | undefined;
+  if (!Array.isArray(content)) return null;
+
+  const toolResult = content.find(
+    (c): c is Parsed =>
+      typeof c === 'object' &&
+      c !== null &&
+      (c as Parsed)['type'] === 'tool_result'
+  );
+  if (!toolResult) return null;
+
+  const toolId = toolResult['tool_use_id'];
+  const rawContent = toolResult['content'];
+  const isError = toolResult['is_error'];
+  if (typeof toolId === 'string') {
+    const contentStr =
+      typeof rawContent === 'string' ? rawContent : JSON.stringify(rawContent);
     return {
-      kind: 'result',
-      result: typeof result === 'string' ? result : '',
-      sessionId: typeof sessionId === 'string' ? sessionId : undefined,
+      kind: 'tool_result',
+      toolId,
+      content: contentStr,
       isError: isError === true,
     };
   }
+  return null;
+}
 
-  // Control requests from Claude
-  if (parsed['type'] === 'control_request') {
-    const requestId = parsed['request_id'];
-    const request = parsed['request'] as Record<string, unknown> | undefined;
-    if (typeof requestId !== 'string') return null;
+/**
+ * Response completion: result message emitted when a turn finishes
+ */
+function parseResultMessage(parsed: Parsed): ParsedStreamEvent | null {
+  const result = parsed['result'];
+  const sessionId = parsed['session_id'];
+  const isError = parsed['is_error'];
+  return {
+    kind: 'result',
+    result: typeof result === 'string' ? result : '',
+    sessionId: typeof sessionId === 'string' ? sessionId : undefined,
+    isError: isError === true,
+  };
+}
 
-    // can_use_tool: SDK escalated from hook "ask" decision
-    if (request?.['subtype'] === 'can_use_tool') {
+function parseControlRequest(parsed: Parsed): ParsedStreamEvent | null {
+  const requestId = parsed['request_id'];
+  const request = parsed['request'] as Parsed | undefined;
+  if (typeof requestId !== 'string') return null;
+
+  // can_use_tool: SDK escalated from hook "ask" decision
+  switch (request?.['subtype']) {
+    case 'can_use_tool': {
       const toolUseId = request['tool_use_id'];
       const toolName = request['tool_name'];
       const toolInput = request['input'];
@@ -163,12 +181,13 @@ export function parseStreamJsonLine(line: string): ParsedStreamEvent | null {
           input: toolInput,
         };
       }
+      return null;
     }
 
     // hook_callback: PreToolUse hook fired — respond directly with allow/deny
-    if (request?.['subtype'] === 'hook_callback') {
+    case 'hook_callback': {
       const callbackId = request['callback_id'];
-      const input = request['input'] as Record<string, unknown> | undefined;
+      const input = request['input'] as Parsed | undefined;
       const toolUseId = input?.['tool_use_id'];
       const toolName = input?.['tool_name'];
       const toolInput = input?.['tool_input'];
@@ -182,15 +201,19 @@ export function parseStreamJsonLine(line: string): ParsedStreamEvent | null {
           input: toolInput,
         };
       }
+      return null;
     }
+    default:
+      return null;
   }
+}
 
-  if (parsed['type'] === 'system' && parsed['subtype'] === 'init') {
-    const sessionId = parsed['session_id'];
-    if (typeof sessionId === 'string') {
-      return { kind: 'init', sessionId };
-    }
+function parseInitMessage(parsed: Parsed): ParsedStreamEvent | null {
+  if (parsed['subtype'] !== 'init') return null;
+
+  const sessionId = parsed['session_id'];
+  if (typeof sessionId === 'string') {
+    return { kind: 'init', sessionId };
   }
-
   return null;
 }

--- a/backend/services/promptBuilder.ts
+++ b/backend/services/promptBuilder.ts
@@ -9,15 +9,6 @@ import type {
 import { AppError } from '../errors/AppError.js';
 import * as templates from './promptTemplates.js';
 
-function requireCustomPrompt(customPrompt?: string): void {
-  if (!customPrompt || customPrompt.trim() === '') {
-    throw new AppError(
-      'customPrompt is required for custom command',
-      HttpStatus.BAD_REQUEST
-    );
-  }
-}
-
 export function buildSystemPrompt(context: CommandContext): string {
   if (context.type === 'pr') {
     return templates.systemPromptForPR(context.prMeta);

--- a/backend/services/promptBuilder.ts
+++ b/backend/services/promptBuilder.ts
@@ -10,10 +10,10 @@ import { AppError } from '../errors/AppError.js';
 import * as templates from './promptTemplates.js';
 
 export function buildSystemPrompt(context: CommandContext): string {
-  if (context.type === 'pr') {
-    return templates.systemPromptForPR(context.prMeta);
-  }
-  return templates.systemPrompt(context.prMeta);
+  return templates.systemPrompt(
+    context.prMeta,
+    context.type === 'pr' ? 'pr' : 'thread'
+  );
 }
 
 export function buildUserPrompt(
@@ -27,78 +27,97 @@ export function buildUserPrompt(
   return buildReviewCommentUserPrompt(command, context, customPrompt);
 }
 
+export function buildBatchUserPrompt(
+  command: ClaudeCommand,
+  contexts: (ReviewCommandContext | CommentCommandContext)[],
+  customPrompt?: string
+): string {
+  if (command === 'custom') requireCustomPrompt(customPrompt);
+
+  const templateFn = batchTemplates[command];
+  if (!templateFn) {
+    throw new AppError(
+      `Command '${command}' is not supported for batch`,
+      HttpStatus.BAD_REQUEST
+    );
+  }
+  const batchSection = templates.batchReviewCommentSection(contexts);
+  return templateFn(batchSection, customPrompt);
+}
+
+// ── PR-level prompt ─────────────────────────────────────────────────
+
+type PrTemplateFn = (
+  repoOwnerName: string,
+  prNumber: number,
+  customPrompt?: string
+) => string;
+
+const prTemplates: Partial<Record<ClaudeCommand, PrTemplateFn>> = {
+  review: (r, n) => templates.reviewPrPrompt(r, n),
+  explain: (r, n) => templates.explainPrPrompt(r, n),
+  custom: (r, n, cp) => templates.customPrPrompt(cp!, r, n),
+};
+
 function buildPrUserPrompt(
   command: ClaudeCommand,
   context: PRCommandContext,
   customPrompt?: string
 ): string {
-  const { repoOwnerName, number: prNumber } = context.prMeta;
+  if (command === 'custom') requireCustomPrompt(customPrompt);
 
-  switch (command) {
-    case 'review':
-      return templates.reviewPrPrompt(repoOwnerName, prNumber);
-    case 'explain':
-      return templates.explainPrPrompt(repoOwnerName, prNumber);
-    case 'custom': {
-      requireCustomPrompt(customPrompt);
-      return templates.customPrPrompt(customPrompt!, repoOwnerName, prNumber);
-    }
-    default:
-      throw new Error(
-        `Command '${command}' is not supported for PR-level context`
-      );
+  const templateFn = prTemplates[command];
+  if (!templateFn) {
+    throw new AppError(
+      `Command '${command}' is not supported for PR-level context`,
+      HttpStatus.BAD_REQUEST
+    );
   }
+  const { repoOwnerName, number: prNumber } = context.prMeta;
+  return templateFn(repoOwnerName, prNumber, customPrompt);
 }
+
+// ── Review comment prompt ───────────────────────────────────────────
+
+type CommentTemplateFn = (
+  reviewComment: string,
+  customPrompt?: string
+) => string;
+
+const commentTemplates: Partial<Record<ClaudeCommand, CommentTemplateFn>> = {
+  explain: (s) => templates.explainPrompt(s),
+  fix: (s) => templates.fixPrompt(s),
+  validate: (s) => templates.validatePrompt(s),
+  custom: (s, cp) => templates.customPrompt(cp!, s),
+};
 
 function buildReviewCommentUserPrompt(
   command: ClaudeCommand,
   context: ReviewCommandContext | CommentCommandContext,
   customPrompt?: string
 ): string {
+  if (command === 'custom') requireCustomPrompt(customPrompt);
+
+  const templateFn = commentTemplates[command];
+  if (!templateFn) {
+    throw new AppError(`Unknown command: ${command}`, HttpStatus.BAD_REQUEST);
+  }
   const reviewComment = templates.reviewCommentSection(context);
-
-  switch (command) {
-    case 'explain':
-      return templates.explainPrompt(reviewComment);
-    case 'fix':
-      return templates.fixPrompt(reviewComment);
-    case 'validate':
-      return templates.validatePrompt(reviewComment);
-    case 'custom': {
-      requireCustomPrompt(customPrompt);
-      return templates.customPrompt(customPrompt!, reviewComment);
-    }
-    default:
-      throw new AppError(`Unknown command: ${command}`, HttpStatus.BAD_REQUEST);
-  }
+  return templateFn(reviewComment, customPrompt);
 }
 
-export function buildBatchUserPrompt(
-  command: ClaudeCommand,
-  contexts: (ReviewCommandContext | CommentCommandContext)[],
-  customPrompt?: string
-): string {
-  const batchSection = templates.batchReviewCommentSection(contexts);
+// ── Batch prompt ────────────────────────────────────────────────────
 
-  switch (command) {
-    case 'fix':
-      return templates.batchFixPrompt(batchSection);
-    case 'explain':
-      return templates.batchExplainPrompt(batchSection);
-    case 'validate':
-      return templates.batchValidatePrompt(batchSection);
-    case 'custom': {
-      requireCustomPrompt(customPrompt);
-      return templates.batchCustomPrompt(customPrompt!, batchSection);
-    }
-    default:
-      throw new AppError(
-        `Command '${command}' is not supported for batch`,
-        HttpStatus.BAD_REQUEST
-      );
-  }
-}
+type BatchTemplateFn = (batchSection: string, customPrompt?: string) => string;
 
+const batchTemplates: Partial<Record<ClaudeCommand, BatchTemplateFn>> = {
+  fix: (s) => templates.batchFixPrompt(s),
+  explain: (s) => templates.batchExplainPrompt(s),
+  validate: (s) => templates.batchValidatePrompt(s),
+  custom: (s, cp) => templates.batchCustomPrompt(cp!, s),
+};
+
+// ── Shared helpers ─────────────────────────────────────────────────
 
 function requireCustomPrompt(customPrompt?: string): void {
   if (!customPrompt || customPrompt.trim() === '') {

--- a/backend/services/promptBuilder.ts
+++ b/backend/services/promptBuilder.ts
@@ -9,6 +9,15 @@ import type {
 import { AppError } from '../errors/AppError.js';
 import * as templates from './promptTemplates.js';
 
+function requireCustomPrompt(customPrompt?: string): void {
+  if (!customPrompt || customPrompt.trim() === '') {
+    throw new AppError(
+      'customPrompt is required for custom command',
+      HttpStatus.BAD_REQUEST
+    );
+  }
+}
+
 export function buildSystemPrompt(context: CommandContext): string {
   if (context.type === 'pr') {
     return templates.systemPromptForPR(context.prMeta);

--- a/backend/services/promptTemplates.ts
+++ b/backend/services/promptTemplates.ts
@@ -15,7 +15,17 @@ export interface SystemPromptParams {
   body: string;
 }
 
-export function systemPrompt(p: SystemPromptParams): string {
+export type ReviewScope = 'pr' | 'thread';
+
+export function systemPrompt(
+  p: SystemPromptParams,
+  scope: ReviewScope = 'thread'
+): string {
+  const guideline =
+    scope === 'pr'
+      ? 'Focus on the overall changes introduced in this pull request.'
+      : 'Focus on the specific review comment provided by the user.';
+
   return `You are a code review assistant for a GitHub Pull Request.
 
 ## PR Context
@@ -29,24 +39,7 @@ ${p.body || '(no description)'}
 ## Guidelines
 - You have access to the local codebase (already checked out to the PR branch).
 - Use \`gh\` CLI or file reading tools to explore additional context when needed.
-- Focus on the specific review comment provided by the user.`;
-}
-
-export function systemPromptForPR(p: SystemPromptParams): string {
-  return `You are a code review assistant for a GitHub Pull Request.
-
-## PR Context
-- Repository: ${p.repoOwnerName}
-- PR #${p.number}: ${p.title}
-- Branch: ${p.headBranch} → ${p.baseBranch}
-
-## PR Description
-${p.body || '(no description)'}
-
-## Guidelines
-- You have access to the local codebase (already checked out to the PR branch).
-- Use \`gh\` CLI or file reading tools to explore additional context when needed.
-- Focus on the overall changes introduced in this pull request.`;
+- ${guideline}`;
 }
 
 // ── Review comment section ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Handler extraction & switch routing**: Break down monolithic `handleClaudeWebSocket`, `parseStreamJsonLine`, and prompt builders into focused per-type handler functions with switch/map-based dispatch instead of if-chains
- **Params object pattern**: Replace `ClaudeSessionManager.execute()` positional args (7 params) with a single `ExecuteParams` interface for clarity and extensibility
- **Template consolidation**: Merge duplicate `systemPrompt` / `systemPromptForPR` into one function with a `ReviewScope` parameter; replace prompt switch statements with lookup maps

## Test plan
- [x] Verify existing `ClaudeSessionManager` tests pass with the new `ExecuteParams` interface
- [x] Confirm WebSocket message routing works for all message types (execute, batchExecute, followUp, abort, approval_response, plan_approval_response)
- [x] Validate prompt building for PR-level, comment-level, and batch commands