### PR TITLE
chore: use dynamic base branch in git-pr skill

### DIFF
--- a/.claude/skills/git-pr/SKILL.md
+++ b/.claude/skills/git-pr/SKILL.md
@@ -9,11 +9,12 @@ Analyze the changes in the current branch, generate a PR title and body in Engli
 </Instruction>
 
 <Steps>
-1. Check current branch status and commit history
-2. Get the diff using `git diff main...HEAD` to see all commits since branching from main
-3. Analyze the changes and generate PR title and body
-4. Push the branch to remote if needed with `-u` flag
-5. Create the PR using `gh pr create`
+1. Determine the base branch dynamically from the repo's default branch using `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` (fallback to `main` if unavailable)
+2. Check current branch status and commit history
+3. Get the diff using `git diff <base>...HEAD` to see all commits since branching from the base
+4. Analyze the changes and generate PR title and body
+5. Push the branch to remote if needed with `-u` flag
+6. Create the PR using `gh pr create --base <base>`
 </Steps>
 
 <Rules>


### PR DESCRIPTION
## Summary
- Detect the repo's default branch via `gh repo view` instead of hardcoding `main` in the git-pr skill
- Use the resolved base branch for both `git diff <base>...HEAD` and `gh pr create --base <base>`
- Ensures PRs target the correct base in repos that use `develop` (or other non-`main` defaults)