### PR TITLE
chore: set up husky pre-commit hook with lint-staged

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx prettier --write \"$CLAUDE_TOOL_INPUT_FILE_PATH\" 2>/dev/null || true"
+            "command": "FILE=$(jq -r '.tool_input.file_path // empty'); [ -n \"$FILE\" ] && [ -f \"$FILE\" ] && npx prettier --write \"$FILE\" 2>/dev/null || true"
           }
         ]
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Generate tsoa routes
+        run: pnpm --filter @lgtmai/backend exec tsoa routes
+
       - name: Lint
         run: pnpm run lint
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm exec lint-staged

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -30,7 +30,7 @@ export async function createApp(
     const { readFileSync } = await import('node:fs');
     const swaggerDocument = JSON.parse(
       readFileSync(join(__dirname, 'public', 'swagger.json'), 'utf-8')
-    );
+    ) as Record<string, unknown>;
     swaggerDocument.servers = [{ url: '/' }];
     app.use(
       '/api-docs',

--- a/backend/controllers/ClaudeWSController.ts
+++ b/backend/controllers/ClaudeWSController.ts
@@ -1,5 +1,6 @@
 import type WebSocket from 'ws';
 import { ClaudeSessionManager } from '../services/claude/ClaudeSessionManager.js';
+import { toUtf8 } from '../utils/wsRawData.js';
 import {
   buildSystemPrompt,
   buildUserPrompt,
@@ -19,9 +20,11 @@ export function handleClaudeWebSocket(ws: WebSocket): void {
   const manager = new ClaudeSessionManager(ws);
 
   ws.on('message', (rawData) => {
+    const text = toUtf8(rawData);
+
     let msg: WsClientMessage;
     try {
-      msg = JSON.parse(rawData.toString()) as WsClientMessage;
+      msg = JSON.parse(text) as WsClientMessage;
     } catch {
       ws.send(
         JSON.stringify({ type: 'error', message: 'Invalid JSON message' })

--- a/backend/controllers/FilesController.ts
+++ b/backend/controllers/FilesController.ts
@@ -14,7 +14,7 @@ export class FilesController extends Controller {
   @Response<ErrorResponse>(400, 'Path is not a directory')
   @Response<ErrorResponse>(403, 'Access to this path is not allowed')
   @Response<ErrorResponse>(404, 'Directory not found')
-  public async browse(@Query() path?: string): Promise<BrowseResponse> {
+  public browse(@Query() path?: string): BrowseResponse {
     return fileSystemService.browse(path);
   }
 }

--- a/backend/dtos/chatSessionSummaryDto.ts
+++ b/backend/dtos/chatSessionSummaryDto.ts
@@ -30,7 +30,7 @@ export class ChatSessionSummaryDto implements ChatSessionSummary {
     this.lastUsedAt = data.lastUsedAt;
   }
 
-  static fromModel(model: ChatSession): ChatSessionSummaryDto {
+  static fromModel(this: void, model: ChatSession): ChatSessionSummaryDto {
     return new ChatSessionSummaryDto({
       id: model.id,
       projectId: model.project_id,

--- a/backend/dtos/ghInlineCommentDto.ts
+++ b/backend/dtos/ghInlineCommentDto.ts
@@ -1,7 +1,10 @@
 import type { PRReview, GhReviewInlineComment } from '../types/pullRequests.js';
 
 export class GhInlineCommentDto {
-  static fromGh(c: GhReviewInlineComment): PRReview['inlineComments'][number] {
+  static fromGh(
+    this: void,
+    c: GhReviewInlineComment
+  ): PRReview['inlineComments'][number] {
     return {
       id: String(c.id),
       ...(c.in_reply_to_id != null

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,22 +1,16 @@
 import js from '@eslint/js';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export default [
+export default defineConfig(
   { ignores: ['dist'] },
-    {
-    files: ['**/*.ts'],
-    ...js.configs.recommended,
-  },
-  ...tseslint.configs.recommended.map((config) => ({
-    files: ['**/*.ts'],
-    ...config,
-  })),
   {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.ts'],
     languageOptions: {
       ecmaVersion: 2022,
@@ -31,5 +25,5 @@ export default [
         { argsIgnorePattern: '^_' },
       ],
     },
-  },
-];
+  }
+);

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -10,7 +10,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export default defineConfig(
   { ignores: ['dist'] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommendedTypeChecked,
+    ],
     files: ['**/*.ts'],
     languageOptions: {
       ecmaVersion: 2022,
@@ -25,8 +28,6 @@ export default defineConfig(
         'error',
         { argsIgnorePattern: '^_' },
       ],
-      '@typescript-eslint/no-floating-promises': 'error',
-      '@typescript-eslint/no-misused-promises': 'error',
       '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   }

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -8,8 +8,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default [
   { ignores: ['dist'] },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
+    {
+    files: ['**/*.ts'],
+    ...js.configs.recommended,
+  },
+  ...tseslint.configs.recommended.map((config) => ({
+    files: ['**/*.ts'],
+    ...config,
+  })),
   {
     files: ['**/*.ts'],
     languageOptions: {

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -16,6 +16,7 @@ export default defineConfig(
       ecmaVersion: 2022,
       globals: globals.node,
       parserOptions: {
+        projectService: true,
         tsconfigRootDir: __dirname,
       },
     },
@@ -24,6 +25,9 @@ export default defineConfig(
         'error',
         { argsIgnorePattern: '^_' },
       ],
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   }
 );

--- a/backend/services/auth.test.ts
+++ b/backend/services/auth.test.ts
@@ -171,12 +171,11 @@ describe('auth service', () => {
         new Error('account "unknown" not found')
       );
 
-      await expect(switchAccount('unknown')).rejects.toMatchObject({
-        message: expect.stringContaining(
-          'Failed to switch GitHub account to "unknown"'
-        ),
-        statusCode: 400,
-      });
+      const result = switchAccount('unknown');
+      await expect(result).rejects.toThrow(
+        'Failed to switch GitHub account to "unknown"'
+      );
+      await expect(result).rejects.toMatchObject({ statusCode: 400 });
     });
   });
 });

--- a/backend/services/claude/ClaudeProcess.ts
+++ b/backend/services/claude/ClaudeProcess.ts
@@ -257,6 +257,8 @@ export class ClaudeProcess extends EventEmitter<ClaudeStreamEvents> {
       case 'init':
         this.emit('init', result.sessionId);
         break;
+      case 'tool_start':
+        break;
       case 'tool_complete':
         this.emit('tool_message', result.toolId, result.toolName, result.input);
         break;

--- a/backend/services/claude/ClaudeSessionManager.test.ts
+++ b/backend/services/claude/ClaudeSessionManager.test.ts
@@ -67,7 +67,7 @@ describe('ClaudeSessionManager', () => {
     const proc = processInstances[0];
     expect(proc).toBeDefined();
 
-    proc!.emit('init', 'claude-session-1');
+    proc.emit('init', 'claude-session-1');
     await Promise.resolve();
 
     expect(mockCreateChatSessionFromExecution).toHaveBeenCalledWith(
@@ -98,7 +98,7 @@ describe('ClaudeSessionManager', () => {
       },
       commandMeta: { command: 'validate', customPrompt: undefined },
     });
-    processInstances[0]!.emit('init', 'claude-session-meta');
+    processInstances[0].emit('init', 'claude-session-meta');
     await Promise.resolve();
     expect(mockCreateChatSessionFromExecution).toHaveBeenCalledWith(
       expect.objectContaining({ projectId: 'p' }),
@@ -127,7 +127,7 @@ describe('ClaudeSessionManager', () => {
     const proc = processInstances[0];
     expect(proc).toBeDefined();
 
-    proc!.emit('done', 0, 'ok', 'claude-session-2');
+    proc.emit('done', 0, 'ok', 'claude-session-2');
     await Promise.resolve();
 
     expect(mockCreateChatSessionFromExecution).not.toHaveBeenCalled();
@@ -162,7 +162,7 @@ describe('ClaudeSessionManager', () => {
 
     const proc = processInstances[0];
     expect(proc).toBeDefined();
-    expect(proc!.systemPrompt).toBe('You are a code review assistant.');
+    expect(proc.systemPrompt).toBe('You are a code review assistant.');
   });
 
   it('leaves systemPrompt undefined when not provided', () => {
@@ -174,7 +174,7 @@ describe('ClaudeSessionManager', () => {
     });
 
     const proc = processInstances[0];
-    expect(proc!.systemPrompt).toBeUndefined();
+    expect(proc.systemPrompt).toBeUndefined();
   });
 
   it('forwards init events from the claude process to websocket', () => {
@@ -190,7 +190,7 @@ describe('ClaudeSessionManager', () => {
     const proc = processInstances[0];
     expect(proc).toBeDefined();
 
-    proc!.emit('init', 'claude-session-2');
+    proc.emit('init', 'claude-session-2');
 
     expect(ws.send).toHaveBeenCalledWith(
       JSON.stringify({

--- a/backend/services/ghUtils.test.ts
+++ b/backend/services/ghUtils.test.ts
@@ -15,19 +15,19 @@ describe('ghUtils', () => {
 
     it('throws BAD_REQUEST for missing slash', () => {
       expect(() => validateRepoOwnerName('noslash')).toThrow(
-        expect.objectContaining({ statusCode: 400 })
+        expect.objectContaining({ statusCode: 400 }) as Error
       );
     });
 
     it('throws BAD_REQUEST for spaces', () => {
       expect(() => validateRepoOwnerName('bad repo name!')).toThrow(
-        expect.objectContaining({ statusCode: 400 })
+        expect.objectContaining({ statusCode: 400 }) as Error
       );
     });
 
     it('throws BAD_REQUEST for empty string', () => {
       expect(() => validateRepoOwnerName('')).toThrow(
-        expect.objectContaining({ statusCode: 400 })
+        expect.objectContaining({ statusCode: 400 }) as Error
       );
     });
   });

--- a/backend/services/prList.test.ts
+++ b/backend/services/prList.test.ts
@@ -247,7 +247,7 @@ describe('fetchPRList', () => {
 
     await fetchPRList('owner/repo', { state: 'closed' });
 
-    const args: string[] = mockExecAsync.mock.calls[0][1];
+    const args = mockExecAsync.mock.calls[0][1] as string[];
     const statesArgs = args.filter(
       (_, i) => args[i - 1] === '-f' && args[i].startsWith('states[]=')
     );
@@ -259,7 +259,7 @@ describe('fetchPRList', () => {
 
     await fetchPRList('owner/repo', { state: 'all' });
 
-    const args: string[] = mockExecAsync.mock.calls[0][1];
+    const args = mockExecAsync.mock.calls[0][1] as string[];
     const statesArgs = args.filter(
       (_, i) => args[i - 1] === '-f' && args[i].startsWith('states[]=')
     );

--- a/backend/utils/batchAsync.test.ts
+++ b/backend/utils/batchAsync.test.ts
@@ -4,7 +4,7 @@ import { batchAsync } from './batchAsync.js';
 describe('batchAsync', () => {
   it('processes all items and returns results in order', async () => {
     const items = [1, 2, 3, 4, 5];
-    const results = await batchAsync(items, 2, async (n) => n * 2);
+    const results = await batchAsync(items, 2, (n) => Promise.resolve(n * 2));
     expect(results).toEqual([2, 4, 6, 8, 10]);
   });
 
@@ -28,22 +28,24 @@ describe('batchAsync', () => {
   });
 
   it('returns empty array for empty input', async () => {
-    const results = await batchAsync([], 5, async (n: number) => n);
+    const results = await batchAsync([], 5, (n: number) => Promise.resolve(n));
     expect(results).toEqual([]);
   });
 
   it('handles batch size larger than items', async () => {
     const items = [1, 2, 3];
-    const results = await batchAsync(items, 100, async (n) => n * 10);
+    const results = await batchAsync(items, 100, (n) =>
+      Promise.resolve(n * 10)
+    );
     expect(results).toEqual([10, 20, 30]);
   });
 
   it('propagates errors from the fn', async () => {
     const items = [1, 2, 3];
     await expect(
-      batchAsync(items, 2, async (n) => {
-        if (n === 2) throw new Error('fail on 2');
-        return n;
+      batchAsync(items, 2, (n) => {
+        if (n === 2) return Promise.reject(new Error('fail on 2'));
+        return Promise.resolve(n);
       })
     ).rejects.toThrow('fail on 2');
   });

--- a/backend/utils/wsRawData.ts
+++ b/backend/utils/wsRawData.ts
@@ -1,0 +1,7 @@
+import type { RawData } from 'ws';
+
+export function toUtf8(rawData: RawData): string {
+  if (Array.isArray(rawData)) return Buffer.concat(rawData).toString('utf-8');
+  if (Buffer.isBuffer(rawData)) return rawData.toString('utf-8');
+  return Buffer.from(rawData).toString('utf-8');
+}

--- a/cli/eslint.config.mjs
+++ b/cli/eslint.config.mjs
@@ -1,22 +1,16 @@
 import js from '@eslint/js';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export default [
+export default defineConfig(
   { ignores: ['dist', 'esbuild.config.mjs'] },
   {
-    files: ['**/*.ts'],
-    ...js.configs.recommended,
-  },
-  ...tseslint.configs.recommended.map((config) => ({
-    files: ['**/*.ts'],
-    ...config,
-  })),
-  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.ts'],
     languageOptions: {
       ecmaVersion: 2022,
@@ -31,5 +25,5 @@ export default [
         { argsIgnorePattern: '^_' },
       ],
     },
-  },
-];
+  }
+);

--- a/cli/eslint.config.mjs
+++ b/cli/eslint.config.mjs
@@ -16,6 +16,7 @@ export default defineConfig(
       ecmaVersion: 2022,
       globals: globals.node,
       parserOptions: {
+        projectService: true,
         tsconfigRootDir: __dirname,
       },
     },
@@ -24,6 +25,7 @@ export default defineConfig(
         'error',
         { argsIgnorePattern: '^_' },
       ],
+      '@typescript-eslint/no-floating-promises': 'error',
     },
   }
 );

--- a/cli/eslint.config.mjs
+++ b/cli/eslint.config.mjs
@@ -1,0 +1,35 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default [
+  { ignores: ['dist', 'esbuild.config.mjs'] },
+  {
+    files: ['**/*.ts'],
+    ...js.configs.recommended,
+  },
+  ...tseslint.configs.recommended.map((config) => ({
+    files: ['**/*.ts'],
+    ...config,
+  })),
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.node,
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_' },
+      ],
+    },
+  },
+];

--- a/cli/launcher.ts
+++ b/cli/launcher.ts
@@ -3,17 +3,21 @@ import { join } from 'node:path';
 import open from 'open';
 import { PORT, FRONTEND_URL } from './utils/ports.js';
 
-async function waitForBackend(url: string, timeoutMs = 30000): Promise<void> {
+async function waitForBackend(
+  url: string,
+  timeoutMs = 30000
+): Promise<boolean> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(1000) });
-      if (res.ok || res.status < 500) return;
+      if (res.ok || res.status < 500) return true;
     } catch {
       // not ready yet
     }
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
+  return false;
 }
 
 export async function launchServers(): Promise<void> {
@@ -33,8 +37,14 @@ export async function launchServers(): Promise<void> {
   processes.push(backend);
 
   // Poll until backend is ready, then open browser
-  waitForBackend(FRONTEND_URL).then(() => {
-    open(FRONTEND_URL);
+  void waitForBackend(FRONTEND_URL).then((ready) => {
+    if (!ready) {
+      console.warn(
+        `\n⚠️  Backend did not respond within the timeout. Skipping browser launch.`
+      );
+      return;
+    }
+    void open(FRONTEND_URL);
   });
 
   const cleanup = () => {

--- a/cli/package.json
+++ b/cli/package.json
@@ -5,14 +5,19 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "rm -rf dist && node esbuild.config.mjs",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "lint": "eslint ."
   },
   "dependencies": {
     "open": "^8.4.2"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.2",
     "@types/node": "^18.19.0",
     "esbuild": "^0.27.3",
-    "typescript": "^5.3.0"
+    "eslint": "^9.39.2",
+    "globals": "^17.3.0",
+    "typescript": "^5.3.0",
+    "typescript-eslint": "^8.56.0"
   }
 }

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": ".",
     "strict": true,

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -4,8 +4,9 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import importLayers from 'eslint-plugin-import-layers';
 import tseslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 
-export default tseslint.config(
+export default defineConfig(
   { ignores: ['dist'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -22,11 +22,9 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,21 @@
     "lint": "pnpm --filter '*' --if-present run lint",
     "lint:fix": "pnpm --filter '*' --if-present run lint:fix",
     "postinstall": "prisma generate --schema=backend/prisma/schema.prisma",
+    "prepare": "husky",
     "prepublishOnly": "pnpm run build"
+  },
+  "lint-staged": {
+    "backend/**/*.ts": [
+      "pnpm --filter @lgtmai/backend exec eslint --fix",
+      "pnpm --filter @lgtmai/backend exec vitest related --run"
+    ],
+    "frontend/**/*.{ts,tsx}": [
+      "pnpm --filter frontend exec eslint --fix",
+      "pnpm --filter frontend exec vitest related --run"
+    ],
+    "cli/**/*.ts": [
+      "pnpm --filter @lgtmai/cli exec eslint --fix"
+    ]
   },
   "keywords": [
     "cli",
@@ -57,6 +71,8 @@
   },
   "devDependencies": {
     "concurrently": "^9.2.1",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "wait-on": "^9.0.4"

--- a/package.json
+++ b/package.json
@@ -21,14 +21,17 @@
   "lint-staged": {
     "backend/**/*.ts": [
       "pnpm --filter @lgtmai/backend exec eslint --fix",
+      "prettier --write",
       "pnpm --filter @lgtmai/backend exec vitest related --run"
     ],
     "frontend/**/*.{ts,tsx}": [
       "pnpm --filter frontend exec eslint --fix",
+      "prettier --write",
       "pnpm --filter frontend exec vitest related --run"
     ],
     "cli/**/*.ts": [
-      "pnpm --filter @lgtmai/cli exec eslint --fix"
+      "pnpm --filter @lgtmai/cli exec eslint --fix",
+      "prettier --write"
     ]
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,12 @@ importers:
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+      lint-staged:
+        specifier: ^16.4.0
+        version: 16.4.0
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -128,15 +134,27 @@ importers:
         specifier: ^8.4.2
         version: 8.4.2
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.2
+        version: 9.39.3
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.130
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3
+      eslint:
+        specifier: ^9.39.2
+        version: 9.39.3(jiti@2.6.1)
+      globals:
+        specifier: ^17.3.0
+        version: 17.3.0
       typescript:
         specifier: ^5.3.0
         version: 5.6.3
+      typescript-eslint:
+        specifier: ^8.56.0
+        version: 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.6.3)
 
   frontend:
     dependencies:
@@ -1466,6 +1484,10 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1608,6 +1630,14 @@ packages:
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -1623,12 +1653,19 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -1976,6 +2013,9 @@ packages:
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1997,6 +2037,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -2109,6 +2153,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -2238,6 +2285,10 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -2379,6 +2430,11 @@ packages:
     resolution: {integrity: sha512-O5kPr7AW7wYd/BBiOezTwnVAnmSNFY+J7hlZD2X5IOxVBetjcHAiTXhzj0gMrnojQlwy+UT1/Y3H3vJ3UlmvLA==}
     engines: {node: '>= 0.4.0'}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -2445,6 +2501,10 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -2540,7 +2600,6 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.31.1:
@@ -2617,6 +2676,15 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
+  lint-staged@16.4.0:
+    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
+    engines: {node: '>=20.17'}
+    hasBin: true
+
+  listr2@9.0.5:
+    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
+    engines: {node: '>=20.0.0'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2632,6 +2700,10 @@ packages:
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -2846,6 +2918,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -2958,6 +3034,10 @@ packages:
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
 
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
@@ -3257,9 +3337,16 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
@@ -3350,6 +3437,14 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -3381,6 +3476,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -3388,6 +3487,14 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -3445,6 +3552,10 @@ packages:
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
@@ -3754,6 +3865,10 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -5164,6 +5279,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -5323,6 +5442,15 @@ snapshots:
 
   classnames@2.5.1: {}
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -5337,11 +5465,15 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@14.0.3: {}
 
   commander@7.2.0: {}
 
@@ -5677,6 +5809,8 @@ snapshots:
 
   electron-to-chromium@1.5.302: {}
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -5691,6 +5825,8 @@ snapshots:
       tapable: 2.3.0
 
   entities@6.0.1: {}
+
+  environment@1.1.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -5836,6 +5972,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter3@5.0.4: {}
+
   expect-type@1.3.0: {}
 
   express@4.22.1:
@@ -5977,6 +6115,8 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -6189,6 +6329,8 @@ snapshots:
 
   http-status@2.1.0: {}
 
+  husky@9.1.7: {}
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -6236,6 +6378,10 @@ snapshots:
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
 
   is-glob@4.0.3:
     dependencies:
@@ -6390,6 +6536,24 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
+  lint-staged@16.4.0:
+    dependencies:
+      commander: 14.0.3
+      listr2: 9.0.5
+      picomatch: 4.0.3
+      string-argv: 0.3.2
+      tinyexec: 1.1.1
+      yaml: 2.8.2
+
+  listr2@9.0.5:
+    dependencies:
+      cli-truncate: 5.2.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -6401,6 +6565,14 @@ snapshots:
   lodash@4.17.21: {}
 
   lodash@4.17.23: {}
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.1.2
+      wrap-ansi: 9.0.2
 
   long@5.3.2: {}
 
@@ -6848,6 +7020,8 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mimic-function@5.0.1: {}
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -6942,6 +7116,10 @@ snapshots:
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   open@8.4.2:
     dependencies:
@@ -7256,7 +7434,14 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 3.0.7
+
   retry@0.12.0: {}
+
+  rfdc@1.4.1: {}
 
   robust-predicates@3.0.2: {}
 
@@ -7389,6 +7574,16 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -7408,6 +7603,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-argv@0.3.2: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -7418,6 +7615,17 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.1.2
+
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
       strip-ansi: 7.1.2
 
   stringify-entities@4.0.4:
@@ -7471,6 +7679,8 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
+
+  tinyexec@1.1.1: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -7807,6 +8017,12 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
+      strip-ansi: 7.1.2
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
       strip-ansi: 7.1.2
 
   ws@8.19.0: {}


### PR DESCRIPTION
## Summary
- Add husky + lint-staged to run per-workspace eslint (and vitest related for backend/frontend) on staged files before commit
- Add eslint config for the cli workspace so it can participate in the staged-file lint pipeline

## Test plan
- [x] Verified hook triggers correctly when staging files in `cli/`, `backend/`, and `frontend/` workspaces
- [x] Confirmed each workspace runs its configured tasks (eslint --fix, plus vitest related for backend/frontend)