### PR TITLE
feat(frontend): timeline tool-call UX with live Bash stderr stream

### DIFF
--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolBubble.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolBubble.tsx
@@ -1,13 +1,13 @@
-import { motion } from 'motion/react';
-import {
-  Terminal,
-  ChevronDown,
-  ChevronRight,
-  Check,
-  XCircle,
-  Loader2,
-} from 'lucide-react';
 import type { GroupedItem } from '../utils/groupMessages';
+import { parseToolInput } from './ToolStep/utils/parseToolInput';
+import type { ToolStepStatus } from './ToolStep/ToolStep';
+import { BashStep } from './ToolStep/components/BashStep';
+import { ReadStep } from './ToolStep/components/ReadStep';
+import { EditStep } from './ToolStep/components/EditStep';
+import { WriteStep } from './ToolStep/components/WriteStep';
+import { GrepStep } from './ToolStep/components/GrepStep';
+import { WebFetchStep } from './ToolStep/components/WebFetchStep';
+import { GenericStep } from './ToolStep/components/GenericStep';
 
 interface Props {
   item: GroupedItem & { kind: 'tool' };
@@ -15,60 +15,92 @@ interface Props {
   onToggle: () => void;
 }
 
+const deriveStatus = (item: GroupedItem & { kind: 'tool' }): ToolStepStatus => {
+  if (item.isRunning) return 'running';
+  if (item.isError) return 'error';
+  if (item.toolName === 'Bash' && (item.stderrChunks?.length ?? 0) > 0)
+    return 'warning';
+  return 'success';
+};
+
 export const ToolBubble = ({ item, isExpanded, onToggle }: Props) => {
+  const status = deriveStatus(item);
+  const parsed = parseToolInput(item.toolName, item.input);
+
+  if (parsed.kind === 'bash') {
+    return (
+      <BashStep
+        command={parsed.command}
+        description={parsed.description}
+        result={item.result}
+        isRunning={item.isRunning}
+        stderrChunks={item.stderrChunks}
+        status={status}
+        chainPosition={item.chainPosition}
+        isExpanded={isExpanded}
+        onToggle={onToggle}
+      />
+    );
+  }
+  if (parsed.kind === 'read') {
+    return (
+      <ReadStep
+        filePath={parsed.filePath}
+        fileName={parsed.fileName}
+        status={status}
+        chainPosition={item.chainPosition}
+      />
+    );
+  }
+  if (parsed.kind === 'edit') {
+    return (
+      <EditStep
+        filePath={parsed.filePath}
+        fileName={parsed.fileName}
+        status={status}
+        chainPosition={item.chainPosition}
+      />
+    );
+  }
+  if (parsed.kind === 'write') {
+    return (
+      <WriteStep
+        filePath={parsed.filePath}
+        fileName={parsed.fileName}
+        status={status}
+        chainPosition={item.chainPosition}
+      />
+    );
+  }
+  if (parsed.kind === 'grep') {
+    return (
+      <GrepStep
+        pattern={parsed.pattern}
+        path={parsed.path}
+        glob={parsed.glob}
+        result={item.result}
+        status={status}
+        chainPosition={item.chainPosition}
+        isExpanded={isExpanded}
+        onToggle={onToggle}
+      />
+    );
+  }
+  if (parsed.kind === 'webfetch') {
+    return (
+      <WebFetchStep
+        url={parsed.url}
+        hostname={parsed.hostname}
+        status={status}
+        chainPosition={item.chainPosition}
+      />
+    );
+  }
   return (
-    <motion.div
-      key={item.id}
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.3 }}
-      className="overflow-hidden rounded-lg border border-purple-200 bg-purple-50"
-    >
-      <button
-        type="button"
-        onClick={onToggle}
-        className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm hover:bg-purple-100"
-      >
-        {isExpanded ? (
-          <ChevronDown className="h-4 w-4 text-purple-500" />
-        ) : (
-          <ChevronRight className="h-4 w-4 text-purple-500" />
-        )}
-        <Terminal className="h-4 w-4 text-purple-600" />
-        <span className="font-medium text-purple-800">{item.toolName}</span>
-        <span className="ml-auto">
-          {item.result === undefined ? (
-            <Loader2 className="h-4 w-4 animate-spin text-purple-500" />
-          ) : item.isError ? (
-            <XCircle className="h-4 w-4 text-red-500" />
-          ) : (
-            <Check className="h-4 w-4 text-green-500" />
-          )}
-        </span>
-      </button>
-      {isExpanded && (
-        <div className="border-t border-purple-200 bg-purple-100/50 p-2">
-          <div className="mb-1 text-xs font-medium text-purple-600">Input:</div>
-          <pre className="max-h-24 overflow-auto text-xs whitespace-pre-wrap text-purple-900">
-            {item.input}
-          </pre>
-          {item.result !== undefined && (
-            <>
-              <div className="mt-2 mb-1 text-xs font-medium text-purple-600">
-                Result:
-              </div>
-              <pre
-                className={`max-h-32 overflow-auto text-xs whitespace-pre-wrap ${
-                  item.isError ? 'text-red-700' : 'text-purple-900'
-                }`}
-              >
-                {item.result.slice(0, 500)}
-                {item.result.length > 500 && '...'}
-              </pre>
-            </>
-          )}
-        </div>
-      )}
-    </motion.div>
+    <GenericStep
+      toolName={item.toolName}
+      status={status}
+      chainPosition={item.chainPosition}
+    />
   );
 };

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/ToolStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/ToolStep.tsx
@@ -1,0 +1,101 @@
+import { type ReactNode } from 'react';
+import { motion } from 'motion/react';
+import { ChevronDown, ChevronRight, type LucideIcon } from 'lucide-react';
+
+export type ToolStepStatus = 'running' | 'success' | 'error' | 'warning';
+export type ChainPosition = 'start' | 'middle' | 'end' | 'single';
+
+interface ExpandableProps {
+  isExpanded: boolean;
+  onToggle: () => void;
+  expandedBody: ReactNode;
+}
+
+interface Props {
+  status: ToolStepStatus;
+  icon: LucideIcon;
+  chainPosition: ChainPosition;
+  toolName: string;
+  summary: ReactNode;
+  body?: ReactNode;
+  expandable?: ExpandableProps;
+}
+
+const DOT_COLOR: Record<ToolStepStatus, string> = {
+  running: 'bg-gray-400',
+  success: 'bg-green-500',
+  error: 'bg-red-500',
+  warning: 'bg-amber-500',
+};
+
+export const ToolStep = ({
+  status,
+  icon: Icon,
+  chainPosition,
+  toolName,
+  summary,
+  body,
+  expandable,
+}: Props) => {
+  const showConnectorAbove =
+    chainPosition === 'middle' || chainPosition === 'end';
+  const showConnectorBelow =
+    chainPosition === 'middle' || chainPosition === 'start';
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+      className="relative flex gap-3"
+    >
+      <div className="relative flex w-5 flex-none flex-col items-center">
+        {showConnectorAbove && (
+          <div className="absolute top-0 bottom-1/2 w-px -translate-y-3 bg-gray-200" />
+        )}
+        <div
+          className={`relative z-10 mt-2 h-2 w-2 rounded-full ${DOT_COLOR[status]} ${
+            status === 'running' ? 'animate-pulse' : ''
+          }`}
+          aria-label={status}
+        />
+        {showConnectorBelow && (
+          <div className="absolute top-1/2 bottom-0 w-px translate-y-3 bg-gray-200" />
+        )}
+      </div>
+
+      <div className="min-w-0 flex-1 pb-1">
+        <div
+          className={`flex items-center gap-2 text-sm ${
+            expandable ? 'cursor-pointer hover:text-gray-900' : 'cursor-default'
+          }`}
+          onClick={expandable?.onToggle}
+          role={expandable ? 'button' : undefined}
+          tabIndex={expandable ? 0 : undefined}
+          onKeyDown={(e) => {
+            if (expandable && (e.key === 'Enter' || e.key === ' ')) {
+              e.preventDefault();
+              expandable.onToggle();
+            }
+          }}
+        >
+          {expandable &&
+            (expandable.isExpanded ? (
+              <ChevronDown className="h-3.5 w-3.5 flex-none text-gray-400" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 flex-none text-gray-400" />
+            ))}
+          <Icon className="h-4 w-4 flex-none text-gray-500" />
+          <span className="font-semibold text-gray-800">{toolName}</span>
+          <span className="min-w-0 flex-1 truncate text-gray-600">
+            {summary}
+          </span>
+        </div>
+        {body && <div className="mt-2 space-y-1.5">{body}</div>}
+        {expandable?.isExpanded && (
+          <div className="mt-2 space-y-1.5">{expandable.expandedBody}</div>
+        )}
+      </div>
+    </motion.div>
+  );
+};

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/ToolStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/ToolStep.tsx
@@ -1,6 +1,6 @@
-import { type ReactNode } from 'react';
 import { motion } from 'motion/react';
 import { ChevronDown, ChevronRight, type LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
 
 export type ToolStepStatus = 'running' | 'success' | 'error' | 'warning';
 export type ChainPosition = 'start' | 'middle' | 'end' | 'single';
@@ -65,32 +65,32 @@ export const ToolStep = ({
       </div>
 
       <div className="min-w-0 flex-1 pb-1">
-        <div
-          className={`flex items-center gap-2 text-sm ${
-            expandable ? 'cursor-pointer hover:text-gray-900' : 'cursor-default'
-          }`}
-          onClick={expandable?.onToggle}
-          role={expandable ? 'button' : undefined}
-          tabIndex={expandable ? 0 : undefined}
-          onKeyDown={(e) => {
-            if (expandable && (e.key === 'Enter' || e.key === ' ')) {
-              e.preventDefault();
-              expandable.onToggle();
-            }
-          }}
-        >
-          {expandable &&
-            (expandable.isExpanded ? (
+        {expandable ? (
+          <button
+            type="button"
+            onClick={expandable.onToggle}
+            className="flex w-full cursor-pointer items-center gap-2 text-left text-sm hover:text-gray-900"
+          >
+            {expandable.isExpanded ? (
               <ChevronDown className="h-3.5 w-3.5 flex-none text-gray-400" />
             ) : (
               <ChevronRight className="h-3.5 w-3.5 flex-none text-gray-400" />
-            ))}
-          <Icon className="h-4 w-4 flex-none text-gray-500" />
-          <span className="font-semibold text-gray-800">{toolName}</span>
-          <span className="min-w-0 flex-1 truncate text-gray-600">
-            {summary}
-          </span>
-        </div>
+            )}
+            <Icon className="h-4 w-4 flex-none text-gray-500" />
+            <span className="font-semibold text-gray-800">{toolName}</span>
+            <span className="min-w-0 flex-1 truncate text-gray-600">
+              {summary}
+            </span>
+          </button>
+        ) : (
+          <div className="flex items-center gap-2 text-sm">
+            <Icon className="h-4 w-4 flex-none text-gray-500" />
+            <span className="font-semibold text-gray-800">{toolName}</span>
+            <span className="min-w-0 flex-1 truncate text-gray-600">
+              {summary}
+            </span>
+          </div>
+        )}
         {body && <div className="mt-2 space-y-1.5">{body}</div>}
         {expandable?.isExpanded && (
           <div className="mt-2 space-y-1.5">{expandable.expandedBody}</div>

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/BashStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/BashStep.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Check, Copy, Terminal } from 'lucide-react';
+import { ToolStep, type ChainPosition, type ToolStepStatus } from '../ToolStep';
+
+interface Props {
+  command: string;
+  description: string | undefined;
+  result: string | undefined;
+  isRunning: boolean;
+  stderrChunks: string[] | undefined;
+  status: ToolStepStatus;
+  chainPosition: ChainPosition;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+const CopyButton = ({ text }: { text: string }) => {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1200);
+      }}
+      className="absolute top-1 right-1 rounded p-1 text-gray-400 opacity-0 transition group-hover:opacity-100 hover:bg-gray-200 hover:text-gray-700"
+      aria-label="Copy"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+};
+
+const Box = ({
+  label,
+  content,
+  maxHeight,
+  muted,
+}: {
+  label: string;
+  content: string;
+  maxHeight: string;
+  muted?: boolean;
+}) => (
+  <div className="group relative overflow-hidden rounded bg-gray-100">
+    <div className="flex items-start">
+      <div className="flex-none px-2 py-1 text-[10px] font-semibold tracking-wide text-gray-400">
+        {label}
+      </div>
+      <pre
+        className={`min-w-0 flex-1 overflow-auto px-2 py-1 font-mono text-xs whitespace-pre-wrap ${
+          muted ? 'text-gray-500' : 'text-gray-800'
+        } ${maxHeight}`}
+      >
+        {content}
+      </pre>
+    </div>
+    <CopyButton text={content} />
+  </div>
+);
+
+export const BashStep = ({
+  command,
+  description,
+  result,
+  isRunning,
+  stderrChunks,
+  status,
+  chainPosition,
+  isExpanded,
+  onToggle,
+}: Props) => {
+  const summary = description ? (
+    <span>{description}</span>
+  ) : (
+    <span className="font-mono text-xs">{command.slice(0, 80)}</span>
+  );
+
+  const outContent = isRunning ? (stderrChunks ?? []).join('') : (result ?? '');
+  const outMaxHeight = isExpanded ? 'max-h-none' : 'max-h-48';
+
+  const body = (
+    <>
+      <Box label="IN" content={command} maxHeight="max-h-24" />
+      <Box
+        label="OUT"
+        content={outContent}
+        maxHeight={outMaxHeight}
+        muted={isRunning}
+      />
+    </>
+  );
+
+  return (
+    <ToolStep
+      status={status}
+      icon={Terminal}
+      chainPosition={chainPosition}
+      toolName="Bash"
+      summary={summary}
+      expandable={{
+        isExpanded,
+        onToggle,
+        expandedBody: null,
+      }}
+      body={body}
+    />
+  );
+};

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/BashStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/BashStep.tsx
@@ -58,7 +58,6 @@ const Box = ({
       {loading ? (
         <div className="flex min-w-0 flex-1 items-center gap-1.5 px-2 py-1 text-xs text-gray-500">
           <Loader2 className="h-3 w-3 animate-spin" />
-          <span>Running…</span>
         </div>
       ) : (
         <pre

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/BashStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/BashStep.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Check, Copy, Terminal } from 'lucide-react';
+import { Check, Copy, Loader2, Terminal } from 'lucide-react';
 import { ToolStep, type ChainPosition, type ToolStepStatus } from '../ToolStep';
 
 interface Props {
@@ -42,26 +42,35 @@ const Box = ({
   content,
   maxHeight,
   muted,
+  loading,
 }: {
   label: string;
   content: string;
   maxHeight: string;
   muted?: boolean;
+  loading?: boolean;
 }) => (
   <div className="group relative overflow-hidden rounded bg-gray-100">
     <div className="flex items-start">
       <div className="flex-none px-2 py-1 text-[10px] font-semibold tracking-wide text-gray-400">
         {label}
       </div>
-      <pre
-        className={`min-w-0 flex-1 overflow-auto px-2 py-1 font-mono text-xs whitespace-pre ${
-          muted ? 'text-gray-500' : 'text-gray-800'
-        } ${maxHeight}`}
-      >
-        {content}
-      </pre>
+      {loading ? (
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 px-2 py-1 text-xs text-gray-500">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          <span>Running…</span>
+        </div>
+      ) : (
+        <pre
+          className={`min-w-0 flex-1 overflow-auto px-2 py-1 font-mono text-xs whitespace-pre ${
+            muted ? 'text-gray-500' : 'text-gray-800'
+          } ${maxHeight}`}
+        >
+          {content}
+        </pre>
+      )}
     </div>
-    <CopyButton text={content} />
+    {!loading && <CopyButton text={content} />}
   </div>
 );
 
@@ -97,6 +106,7 @@ export const BashStep = ({
         content={outContent}
         maxHeight={outMaxHeight}
         muted={isRunning}
+        loading={isRunning && !outContent}
       />
     </>
   );

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/BashStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/BashStep.tsx
@@ -54,7 +54,7 @@ const Box = ({
         {label}
       </div>
       <pre
-        className={`min-w-0 flex-1 overflow-auto px-2 py-1 font-mono text-xs whitespace-pre-wrap ${
+        className={`min-w-0 flex-1 overflow-auto px-2 py-1 font-mono text-xs whitespace-pre ${
           muted ? 'text-gray-500' : 'text-gray-800'
         } ${maxHeight}`}
       >
@@ -83,11 +83,15 @@ export const BashStep = ({
   );
 
   const outContent = isRunning ? (stderrChunks ?? []).join('') : (result ?? '');
-  const outMaxHeight = isExpanded ? 'max-h-none' : 'max-h-48';
+  const outMaxHeight = isExpanded ? 'max-h-none' : 'max-h-24';
 
   const body = (
     <>
-      <Box label="IN" content={command} maxHeight="max-h-24" />
+      <Box
+        label="IN"
+        content={command}
+        maxHeight={isExpanded ? 'max-h-none' : 'max-h-16'}
+      />
       <Box
         label="OUT"
         content={outContent}

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/EditStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/EditStep.tsx
@@ -1,0 +1,30 @@
+import { Pencil } from 'lucide-react';
+import { ToolStep, type ChainPosition, type ToolStepStatus } from '../ToolStep';
+
+interface Props {
+  filePath: string;
+  fileName: string;
+  status: ToolStepStatus;
+  chainPosition: ChainPosition;
+}
+
+export const EditStep = ({
+  filePath,
+  fileName,
+  status,
+  chainPosition,
+}: Props) => {
+  return (
+    <ToolStep
+      status={status}
+      icon={Pencil}
+      chainPosition={chainPosition}
+      toolName="Edit"
+      summary={
+        <span title={filePath} className="font-mono text-xs">
+          {fileName}
+        </span>
+      }
+    />
+  );
+};

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/GenericStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/GenericStep.tsx
@@ -1,0 +1,20 @@
+import { Wrench } from 'lucide-react';
+import { ToolStep, type ChainPosition, type ToolStepStatus } from '../ToolStep';
+
+interface Props {
+  toolName: string;
+  status: ToolStepStatus;
+  chainPosition: ChainPosition;
+}
+
+export const GenericStep = ({ toolName, status, chainPosition }: Props) => {
+  return (
+    <ToolStep
+      status={status}
+      icon={Wrench}
+      chainPosition={chainPosition}
+      toolName={toolName}
+      summary={null}
+    />
+  );
+};

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/GrepStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/GrepStep.tsx
@@ -44,15 +44,19 @@ export const GrepStep = ({
       chainPosition={chainPosition}
       toolName="Grep"
       summary={summary}
-      expandable={{
-        isExpanded,
-        onToggle,
-        expandedBody: (
-          <pre className="max-h-64 overflow-auto rounded bg-gray-100 p-2 font-mono text-xs whitespace-pre-wrap text-gray-800">
-            {result ?? ''}
-          </pre>
-        ),
-      }}
+      expandable={
+        result !== undefined
+          ? {
+              isExpanded,
+              onToggle,
+              expandedBody: (
+                <pre className="max-h-64 overflow-auto rounded bg-gray-100 p-2 font-mono text-xs whitespace-pre-wrap text-gray-800">
+                  {result}
+                </pre>
+              ),
+            }
+          : undefined
+      }
     />
   );
 };

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/GrepStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/GrepStep.tsx
@@ -1,0 +1,58 @@
+import { Search } from 'lucide-react';
+import { ToolStep, type ChainPosition, type ToolStepStatus } from '../ToolStep';
+
+interface Props {
+  pattern: string;
+  path: string | undefined;
+  glob: string | undefined;
+  result: string | undefined;
+  status: ToolStepStatus;
+  chainPosition: ChainPosition;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+const lineCount = (s: string): number => s.split('\n').filter(Boolean).length;
+
+export const GrepStep = ({
+  pattern,
+  path,
+  glob,
+  result,
+  status,
+  chainPosition,
+  isExpanded,
+  onToggle,
+}: Props) => {
+  const scope = path ?? glob;
+  const summary = (
+    <span className="font-mono text-xs">
+      <span className="text-gray-900">&quot;{pattern}&quot;</span>
+      {scope && <span className="text-gray-500"> in {scope}</span>}
+      {result !== undefined && (
+        <span className="ml-2 text-gray-400">
+          {lineCount(result)} lines of output
+        </span>
+      )}
+    </span>
+  );
+
+  return (
+    <ToolStep
+      status={status}
+      icon={Search}
+      chainPosition={chainPosition}
+      toolName="Grep"
+      summary={summary}
+      expandable={{
+        isExpanded,
+        onToggle,
+        expandedBody: (
+          <pre className="max-h-64 overflow-auto rounded bg-gray-100 p-2 font-mono text-xs whitespace-pre-wrap text-gray-800">
+            {result ?? ''}
+          </pre>
+        ),
+      }}
+    />
+  );
+};

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/ReadStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/ReadStep.tsx
@@ -1,0 +1,30 @@
+import { FileText } from 'lucide-react';
+import { ToolStep, type ChainPosition, type ToolStepStatus } from '../ToolStep';
+
+interface Props {
+  filePath: string;
+  fileName: string;
+  status: ToolStepStatus;
+  chainPosition: ChainPosition;
+}
+
+export const ReadStep = ({
+  filePath,
+  fileName,
+  status,
+  chainPosition,
+}: Props) => {
+  return (
+    <ToolStep
+      status={status}
+      icon={FileText}
+      chainPosition={chainPosition}
+      toolName="Read"
+      summary={
+        <span title={filePath} className="font-mono text-xs">
+          {fileName}
+        </span>
+      }
+    />
+  );
+};

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/WebFetchStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/WebFetchStep.tsx
@@ -1,0 +1,30 @@
+import { Globe } from 'lucide-react';
+import { ToolStep, type ChainPosition, type ToolStepStatus } from '../ToolStep';
+
+interface Props {
+  url: string;
+  hostname: string;
+  status: ToolStepStatus;
+  chainPosition: ChainPosition;
+}
+
+export const WebFetchStep = ({
+  url,
+  hostname,
+  status,
+  chainPosition,
+}: Props) => {
+  return (
+    <ToolStep
+      status={status}
+      icon={Globe}
+      chainPosition={chainPosition}
+      toolName="WebFetch"
+      summary={
+        <span title={url} className="font-mono text-xs">
+          {hostname}
+        </span>
+      }
+    />
+  );
+};

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/WriteStep.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/components/WriteStep.tsx
@@ -1,0 +1,30 @@
+import { FilePlus } from 'lucide-react';
+import { ToolStep, type ChainPosition, type ToolStepStatus } from '../ToolStep';
+
+interface Props {
+  filePath: string;
+  fileName: string;
+  status: ToolStepStatus;
+  chainPosition: ChainPosition;
+}
+
+export const WriteStep = ({
+  filePath,
+  fileName,
+  status,
+  chainPosition,
+}: Props) => {
+  return (
+    <ToolStep
+      status={status}
+      icon={FilePlus}
+      chainPosition={chainPosition}
+      toolName="Write"
+      summary={
+        <span title={filePath} className="font-mono text-xs">
+          {fileName}
+        </span>
+      }
+    />
+  );
+};

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/utils/parseToolInput.test.ts
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/utils/parseToolInput.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { parseToolInput } from './parseToolInput';
+
+describe('parseToolInput', () => {
+  it('parses Bash input', () => {
+    const input = JSON.stringify({
+      command: 'ls -la',
+      description: 'List files',
+    });
+    const parsed = parseToolInput('Bash', input);
+    expect(parsed).toEqual({
+      kind: 'bash',
+      command: 'ls -la',
+      description: 'List files',
+    });
+  });
+
+  it('parses Bash input without description', () => {
+    const parsed = parseToolInput('Bash', JSON.stringify({ command: 'pwd' }));
+    expect(parsed).toEqual({
+      kind: 'bash',
+      command: 'pwd',
+      description: undefined,
+    });
+  });
+
+  it('parses Read input with basename', () => {
+    const parsed = parseToolInput(
+      'Read',
+      JSON.stringify({ file_path: '/a/b/c.ts' })
+    );
+    expect(parsed).toEqual({
+      kind: 'read',
+      filePath: '/a/b/c.ts',
+      fileName: 'c.ts',
+    });
+  });
+
+  it('parses Edit input with basename', () => {
+    const parsed = parseToolInput(
+      'Edit',
+      JSON.stringify({
+        file_path: '/a/b.ts',
+        old_string: 'x',
+        new_string: 'y',
+      })
+    );
+    expect(parsed).toEqual({
+      kind: 'edit',
+      filePath: '/a/b.ts',
+      fileName: 'b.ts',
+    });
+  });
+
+  it('parses Write input with basename', () => {
+    const parsed = parseToolInput(
+      'Write',
+      JSON.stringify({ file_path: '/a/b.ts', content: '…' })
+    );
+    expect(parsed).toEqual({
+      kind: 'write',
+      filePath: '/a/b.ts',
+      fileName: 'b.ts',
+    });
+  });
+
+  it('falls back to the full path when basename cannot be derived', () => {
+    const parsed = parseToolInput('Read', JSON.stringify({ file_path: '/' }));
+    expect(parsed).toEqual({ kind: 'read', filePath: '/', fileName: '/' });
+  });
+
+  it('parses Grep input with path', () => {
+    const parsed = parseToolInput(
+      'Grep',
+      JSON.stringify({ pattern: 'foo', path: 'src' })
+    );
+    expect(parsed).toEqual({
+      kind: 'grep',
+      pattern: 'foo',
+      path: 'src',
+      glob: undefined,
+    });
+  });
+
+  it('parses Grep input with glob', () => {
+    const parsed = parseToolInput(
+      'Grep',
+      JSON.stringify({ pattern: 'foo', glob: '*.ts' })
+    );
+    expect(parsed).toEqual({
+      kind: 'grep',
+      pattern: 'foo',
+      path: undefined,
+      glob: '*.ts',
+    });
+  });
+
+  it('parses WebFetch input', () => {
+    const parsed = parseToolInput(
+      'WebFetch',
+      JSON.stringify({ url: 'https://example.com/path?q=1' })
+    );
+    expect(parsed).toEqual({
+      kind: 'webfetch',
+      url: 'https://example.com/path?q=1',
+      hostname: 'example.com',
+    });
+  });
+
+  it('returns generic for unknown tool', () => {
+    const parsed = parseToolInput('UnknownTool', JSON.stringify({ foo: 1 }));
+    expect(parsed).toEqual({ kind: 'generic', raw: '{\n  "foo": 1\n}' });
+  });
+
+  it('returns generic when input is invalid JSON', () => {
+    const parsed = parseToolInput('Bash', 'not-json');
+    expect(parsed).toEqual({ kind: 'generic', raw: 'not-json' });
+  });
+
+  it('returns generic when shape is wrong', () => {
+    const parsed = parseToolInput('Bash', JSON.stringify({ not_command: 1 }));
+    expect(parsed).toEqual({
+      kind: 'generic',
+      raw: '{\n  "not_command": 1\n}',
+    });
+  });
+});

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/utils/parseToolInput.ts
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/ToolStep/utils/parseToolInput.ts
@@ -1,0 +1,106 @@
+export type ParsedToolInput =
+  | { kind: 'bash'; command: string; description: string | undefined }
+  | { kind: 'read'; filePath: string; fileName: string }
+  | { kind: 'edit'; filePath: string; fileName: string }
+  | { kind: 'write'; filePath: string; fileName: string }
+  | {
+      kind: 'grep';
+      pattern: string;
+      path: string | undefined;
+      glob: string | undefined;
+    }
+  | { kind: 'webfetch'; url: string; hostname: string }
+  | { kind: 'generic'; raw: string };
+
+const isString = (v: unknown): v is string => typeof v === 'string';
+
+const reformat = (raw: string): string => {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+};
+
+const basename = (p: string): string => {
+  const segments = p.split('/').filter(Boolean);
+  return segments[segments.length - 1] ?? p;
+};
+
+export const parseToolInput = (
+  toolName: string,
+  rawInput: string
+): ParsedToolInput => {
+  let data: unknown;
+  try {
+    data = JSON.parse(rawInput);
+  } catch {
+    return { kind: 'generic', raw: rawInput };
+  }
+  if (typeof data !== 'object' || data === null) {
+    return { kind: 'generic', raw: reformat(rawInput) };
+  }
+  const obj = data as Record<string, unknown>;
+
+  switch (toolName) {
+    case 'Bash': {
+      if (!isString(obj.command))
+        return { kind: 'generic', raw: reformat(rawInput) };
+      return {
+        kind: 'bash',
+        command: obj.command,
+        description: isString(obj.description) ? obj.description : undefined,
+      };
+    }
+    case 'Read': {
+      if (!isString(obj.file_path))
+        return { kind: 'generic', raw: reformat(rawInput) };
+      return {
+        kind: 'read',
+        filePath: obj.file_path,
+        fileName: basename(obj.file_path),
+      };
+    }
+    case 'Edit': {
+      if (!isString(obj.file_path))
+        return { kind: 'generic', raw: reformat(rawInput) };
+      return {
+        kind: 'edit',
+        filePath: obj.file_path,
+        fileName: basename(obj.file_path),
+      };
+    }
+    case 'Write': {
+      if (!isString(obj.file_path))
+        return { kind: 'generic', raw: reformat(rawInput) };
+      return {
+        kind: 'write',
+        filePath: obj.file_path,
+        fileName: basename(obj.file_path),
+      };
+    }
+    case 'Grep': {
+      if (!isString(obj.pattern))
+        return { kind: 'generic', raw: reformat(rawInput) };
+      return {
+        kind: 'grep',
+        pattern: obj.pattern,
+        path: isString(obj.path) ? obj.path : undefined,
+        glob: isString(obj.glob) ? obj.glob : undefined,
+      };
+    }
+    case 'WebFetch': {
+      if (!isString(obj.url))
+        return { kind: 'generic', raw: reformat(rawInput) };
+      let hostname = obj.url;
+      try {
+        hostname = new URL(obj.url).hostname;
+      } catch {
+        // keep the raw url as the hostname fallback
+      }
+      return { kind: 'webfetch', url: obj.url, hostname };
+    }
+    default:
+      return { kind: 'generic', raw: reformat(rawInput) };
+  }
+};

--- a/frontend/src/domains/PRDetail/components/ChatPanel/utils/groupMessages.test.ts
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/utils/groupMessages.test.ts
@@ -114,6 +114,18 @@ describe('groupMessages — isRunning', () => {
     const toolItem = result.find((i) => i.kind === 'tool')!;
     expect(toolItem.isRunning).toBe(false);
   });
+
+  it('distinguishes running vs completed tools in the same list', () => {
+    const result = groupMessages(
+      [tool('1', 't1'), toolResult('2', 't1'), tool('3', 't2')],
+      true
+    );
+    const tools = result.filter((i) => i.kind === 'tool');
+    expect(tools[0].isRunning).toBe(false);
+    expect(tools[0].result).toBe('ok');
+    expect(tools[1].isRunning).toBe(true);
+    expect(tools[1].result).toBeUndefined();
+  });
 });
 
 describe('groupMessages — stderrChunks', () => {

--- a/frontend/src/domains/PRDetail/components/ChatPanel/utils/groupMessages.test.ts
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/utils/groupMessages.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { groupMessages } from './groupMessages';
+import type { ClaudeMessage } from '../../../hooks/useClaudeWebSocket/types';
+
+const tool = (
+  id: string,
+  toolId: string,
+  toolName = 'Bash',
+  extra: Partial<ClaudeMessage> = {}
+): ClaudeMessage => ({
+  id,
+  type: 'tool',
+  content: '{}',
+  toolName,
+  toolId,
+  timestamp: new Date(),
+  ...extra,
+});
+
+const toolResult = (
+  id: string,
+  toolId: string,
+  content = 'ok',
+  isError = false
+): ClaudeMessage => ({
+  id,
+  type: 'tool_result',
+  content,
+  toolId,
+  isError,
+  timestamp: new Date(),
+});
+
+const text = (id: string, content = 'hello'): ClaudeMessage => ({
+  id,
+  type: 'text',
+  content,
+  timestamp: new Date(),
+});
+
+const user = (id: string, content = 'hi'): ClaudeMessage => ({
+  id,
+  type: 'user',
+  content,
+  timestamp: new Date(),
+});
+
+describe('groupMessages — chainPosition', () => {
+  it('assigns "single" to a lone tool', () => {
+    const result = groupMessages([tool('1', 't1')], false);
+    const toolItem = result.find((i) => i.kind === 'tool')!;
+    expect(toolItem.chainPosition).toBe('single');
+  });
+
+  it('assigns start/end to a two-tool chain', () => {
+    const result = groupMessages([tool('1', 't1'), tool('2', 't2')], false);
+    const tools = result.filter((i) => i.kind === 'tool');
+    expect(tools[0].chainPosition).toBe('start');
+    expect(tools[1].chainPosition).toBe('end');
+  });
+
+  it('assigns start/middle/end to a three-tool chain', () => {
+    const result = groupMessages(
+      [tool('1', 't1'), tool('2', 't2'), tool('3', 't3')],
+      false
+    );
+    const tools = result.filter((i) => i.kind === 'tool');
+    expect(tools.map((t) => t.chainPosition)).toEqual([
+      'start',
+      'middle',
+      'end',
+    ]);
+  });
+
+  it('breaks chain at text bubble', () => {
+    const result = groupMessages(
+      [tool('1', 't1'), text('2', 'some text'), tool('3', 't3')],
+      false
+    );
+    const tools = result.filter((i) => i.kind === 'tool');
+    expect(tools[0].chainPosition).toBe('single');
+    expect(tools[1].chainPosition).toBe('single');
+  });
+
+  it('breaks chain at user bubble', () => {
+    const result = groupMessages(
+      [tool('1', 't1'), user('2'), tool('3', 't3')],
+      false
+    );
+    const tools = result.filter((i) => i.kind === 'tool');
+    expect(tools[0].chainPosition).toBe('single');
+    expect(tools[1].chainPosition).toBe('single');
+  });
+});
+
+describe('groupMessages — isRunning', () => {
+  it('is true when tool has no result and connected', () => {
+    const result = groupMessages([tool('1', 't1')], true);
+    const toolItem = result.find((i) => i.kind === 'tool')!;
+    expect(toolItem.isRunning).toBe(true);
+  });
+
+  it('is false when tool has a result', () => {
+    const result = groupMessages(
+      [tool('1', 't1'), toolResult('2', 't1')],
+      true
+    );
+    const toolItem = result.find((i) => i.kind === 'tool')!;
+    expect(toolItem.isRunning).toBe(false);
+  });
+
+  it('is false when disconnected even without result', () => {
+    const result = groupMessages([tool('1', 't1')], false);
+    const toolItem = result.find((i) => i.kind === 'tool')!;
+    expect(toolItem.isRunning).toBe(false);
+  });
+});
+
+describe('groupMessages — stderrChunks', () => {
+  it('passes through stderrChunks from source message', () => {
+    const result = groupMessages(
+      [tool('1', 't1', 'Bash', { stderrChunks: ['a', 'b'] })],
+      true
+    );
+    const toolItem = result.find((i) => i.kind === 'tool')!;
+    expect(toolItem.stderrChunks).toEqual(['a', 'b']);
+  });
+
+  it('defaults stderrChunks to undefined when not set', () => {
+    const result = groupMessages([tool('1', 't1')], true);
+    const toolItem = result.find((i) => i.kind === 'tool')!;
+    expect(toolItem.stderrChunks).toBeUndefined();
+  });
+});

--- a/frontend/src/domains/PRDetail/components/ChatPanel/utils/groupMessages.ts
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/utils/groupMessages.ts
@@ -22,6 +22,9 @@ export type GroupedItem =
       input: string;
       result?: string;
       isError?: boolean;
+      stderrChunks?: string[];
+      isRunning: boolean;
+      chainPosition: 'start' | 'middle' | 'end' | 'single';
     };
 
 export const groupMessages = (
@@ -63,6 +66,9 @@ export const groupMessages = (
         toolId: msg.toolId,
         toolName: msg.toolName || 'Unknown',
         input: msg.content,
+        stderrChunks: msg.stderrChunks,
+        isRunning: false,
+        chainPosition: 'single',
       };
       toolMap.set(msg.toolId, toolItem);
       result.push(toolItem);
@@ -84,7 +90,26 @@ export const groupMessages = (
     }
   }
 
-  // The last text block is still streaming only if we're connected
   flushText(isConnected);
+
+  // Second pass: assign chainPosition and isRunning for tool items.
+  for (let i = 0; i < result.length; i++) {
+    const item = result[i];
+    if (item.kind !== 'tool') continue;
+    const prev = result[i - 1];
+    const next = result[i + 1];
+    const hasPrev = prev?.kind === 'tool';
+    const hasNext = next?.kind === 'tool';
+    item.chainPosition =
+      hasPrev && hasNext
+        ? 'middle'
+        : hasPrev
+          ? 'end'
+          : hasNext
+            ? 'start'
+            : 'single';
+    item.isRunning = item.result === undefined && isConnected;
+  }
+
   return result;
 };

--- a/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/types.ts
+++ b/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/types.ts
@@ -38,6 +38,7 @@ export interface ClaudeMessage {
   toolName?: string;
   toolId?: string;
   isError?: boolean;
+  stderrChunks?: string[];
   timestamp: Date;
 }
 

--- a/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useClaudeWebSocket.ts
+++ b/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useClaudeWebSocket.ts
@@ -54,6 +54,7 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
     fileChanges,
     setFileChanges,
     addMessage,
+    appendStderrChunk,
     clearMessages,
     addUserMessage,
     loadHistoryMessages,
@@ -93,7 +94,7 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
           });
           break;
         case 'stderr':
-          addMessage({ type: 'stderr', content: data.chunk });
+          appendStderrChunk(data.chunk);
           break;
         case 'error':
           addMessage({ type: 'error', content: data.message });
@@ -129,7 +130,13 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
           break;
       }
     });
-  }, [addMessage, setApproval, setFileChanges, setOnMessage]);
+  }, [
+    addMessage,
+    appendStderrChunk,
+    setApproval,
+    setFileChanges,
+    setOnMessage,
+  ]);
 
   const execute = useCallback(
     (

--- a/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useWebSocketMessages.ts
+++ b/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useWebSocketMessages.ts
@@ -23,7 +23,7 @@ export function useWebSocketMessages() {
     setMessages((prev) => {
       for (let i = prev.length - 1; i >= 0; i--) {
         const msg = prev[i];
-        if (msg.type === 'tool') {
+        if (msg.type === 'tool' && msg.toolName === 'Bash') {
           const hasResult = prev.some(
             (m) => m.type === 'tool_result' && m.toolId === msg.toolId
           );

--- a/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useWebSocketMessages.ts
+++ b/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useWebSocketMessages.ts
@@ -19,6 +19,28 @@ export function useWebSocketMessages() {
     []
   );
 
+  const appendStderrChunk = useCallback((chunk: string) => {
+    setMessages((prev) => {
+      for (let i = prev.length - 1; i >= 0; i--) {
+        const msg = prev[i];
+        if (msg.type === 'tool') {
+          const hasResult = prev.some(
+            (m) => m.type === 'tool_result' && m.toolId === msg.toolId
+          );
+          if (!hasResult) {
+            const next = [...prev];
+            next[i] = {
+              ...msg,
+              stderrChunks: [...(msg.stderrChunks ?? []), chunk],
+            };
+            return next;
+          }
+        }
+      }
+      return prev;
+    });
+  }, []);
+
   const clearMessages = useCallback(() => {
     setMessages([]);
     setFileChanges(null);
@@ -40,6 +62,7 @@ export function useWebSocketMessages() {
     fileChanges,
     setFileChanges,
     addMessage,
+    appendStderrChunk,
     clearMessages,
     addUserMessage,
     loadHistoryMessages,


### PR DESCRIPTION
## Summary

- Replace the generic purple `ToolBubble` with a timeline-style, per-tool renderer (`BashStep`, `ReadStep`, `EditStep`, `WriteStep`, `GrepStep`, `WebFetchStep`, `GenericStep`) that share a `ToolStep` wrapper drawing status dots and connector lines only between consecutive tool steps.
- Attribute WebSocket `stderr` events to the most recent in-flight Bash tool message via a new `appendStderrChunk` action so users see live stderr streaming in the Bash OUT box during long-running commands, with a spinner placeholder before any output lands.
- Introduce a pure `parseToolInput` utility and extend `groupMessages` with `chainPosition` / `isRunning` / pass-through `stderrChunks` so the dispatcher can pick per-tool renderers and compute status (running / success / error / warning) without side effects.

## Data flow

```mermaid
flowchart LR
  WS[WebSocket events] --> HK[useClaudeWebSocket]
  HK -- stderr --> ASC[appendStderrChunk]
  HK -- tool / tool_result --> AM[addMessage]
  ASC --> MSG[messages]
  AM --> MSG
  MSG --> GM[groupMessages<br/>+ chainPosition<br/>+ isRunning]
  GM --> CP[ChatPanel]
  CP --> TB[ToolBubble<br/>dispatcher]
  TB --> PI[parseToolInput]
  PI --> BS[BashStep]
  PI --> OS[Read / Edit / Write /<br/>WebFetch / Generic]
  PI --> GS[GrepStep]
  BS --> TS[ToolStep wrapper<br/>dot + connector]
  OS --> TS
  GS --> TS
```

## Test plan

- [ ] \`pnpm --filter frontend test\` — 75/75 green (11 new groupMessages + 12 new parseToolInput cases)
- [ ] \`pnpm --filter frontend build\` and \`lint\` clean
- [ ] Run \`pnpm run dev\`; in a PR chat session, verify:
  - [ ] Bash shows inline IN/OUT with copy buttons; spinner appears while running with no output yet
  - [ ] Bash stderr streams live into OUT during long commands; swaps to stdout on completion
  - [ ] Bash stderr without \`isError\` shows an amber warning dot
  - [ ] Read / Edit / Write / WebFetch show single-line headers with full path/url in hover tooltip
  - [ ] Grep becomes expandable only after result arrives; summary shows \`"pattern" in path N lines of output\`
  - [ ] Connector line appears only between consecutive tool steps and breaks when a text or user bubble appears
  - [ ] Session resume (history) still renders tools correctly