### PR TITLE
feat(chat): add Stop/Abort functionality to chat streaming

### DIFF
--- a/backend/services/claude/ClaudeProcess.ts
+++ b/backend/services/claude/ClaudeProcess.ts
@@ -50,6 +50,7 @@ export class ClaudeProcess extends EventEmitter<ClaudeStreamEvents> {
   private readonly lineBuffer = new LineBuffer();
   private errored = false;
   private resultReceived = false;
+  private aborted = false;
 
   private static readonly HOOKS_BY_MODE: Record<
     string,
@@ -205,6 +206,7 @@ export class ClaudeProcess extends EventEmitter<ClaudeStreamEvents> {
   }
 
   abort(): void {
+    this.aborted = true;
     this.childProcess?.kill();
   }
 
@@ -233,9 +235,14 @@ export class ClaudeProcess extends EventEmitter<ClaudeStreamEvents> {
     const isAbnormalExit = code !== 0 && code !== null;
 
     if (this.resultReceived) {
-      if (isAbnormalExit) {
+      if (isAbnormalExit && !this.aborted) {
         this.emit('error', `Process exited with code ${code} after completion`);
       }
+      return;
+    }
+
+    if (this.aborted) {
+      this.emit('done', exitCode, '', undefined);
       return;
     }
 

--- a/frontend/src/domains/PRDetail/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/ChatPanel.tsx
@@ -53,8 +53,7 @@ export const ChatPanel = ({
   const { containerRef, handleScroll } = useAutoScroll(messages);
 
   const lastMessage = messages[messages.length - 1];
-  const isWaitingForResponse =
-    status === 'connected' && lastMessage?.type === 'user';
+  const isWaitingForResponse = isStreaming && lastMessage?.type === 'user';
 
   const showActionSelector =
     mode === 'action-selection' && messages.length === 0 && onExecuteAction;

--- a/frontend/src/domains/PRDetail/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/ChatPanel.tsx
@@ -48,7 +48,7 @@ export const ChatPanel = ({
 }: Props) => {
   const { title, prContext, onExecuteAction, onResumeSession, onSendFollowUp } =
     state;
-  const { messages, status, sessionId, fileChanges } = ws;
+  const { messages, status, sessionId, fileChanges, isStreaming, stop } = ws;
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const { containerRef, handleScroll } = useAutoScroll(messages);
 
@@ -174,7 +174,9 @@ export const ChatPanel = ({
         onSendFollowUp && (
           <FollowUpInput
             sessionId={state.claudeSessionId || sessionId}
+            isStreaming={isStreaming}
             onSendFollowUp={onSendFollowUp}
+            onStop={stop}
           />
         )}
     </div>

--- a/frontend/src/domains/PRDetail/components/ChatPanel/components/FollowUpInput.tsx
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/components/FollowUpInput.tsx
@@ -1,16 +1,24 @@
 import { useState } from 'react';
-import { Send } from 'lucide-react';
+import { Send, Square } from 'lucide-react';
 
 interface Props {
   sessionId?: string | null;
+  isStreaming: boolean;
   onSendFollowUp: (message: string) => void;
+  onStop: () => void;
 }
 
-export const FollowUpInput = ({ sessionId, onSendFollowUp }: Props) => {
+export const FollowUpInput = ({
+  sessionId,
+  isStreaming,
+  onSendFollowUp,
+  onStop,
+}: Props) => {
   const [input, setInput] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (isStreaming) return;
     if (!input.trim()) return;
     onSendFollowUp(input.trim());
     setInput('');
@@ -29,13 +37,25 @@ export const FollowUpInput = ({ sessionId, onSendFollowUp }: Props) => {
           placeholder="Ask a follow-up question..."
           className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
         />
-        <button
-          type="submit"
-          disabled={!input.trim() || !sessionId}
-          className="cursor-pointer rounded-lg bg-indigo-600 px-4 py-2 text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-gray-300"
-        >
-          <Send className="h-4 w-4" />
-        </button>
+        {isStreaming ? (
+          <button
+            type="button"
+            onClick={onStop}
+            className="cursor-pointer rounded-lg bg-gray-800 px-4 py-2 text-white transition-colors hover:bg-gray-900"
+            aria-label="Stop response"
+          >
+            <Square className="h-4 w-4" fill="currentColor" />
+          </button>
+        ) : (
+          <button
+            type="submit"
+            disabled={!input.trim() || !sessionId}
+            className="cursor-pointer rounded-lg bg-indigo-600 px-4 py-2 text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-gray-300"
+            aria-label="Send"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+        )}
       </div>
     </form>
   );

--- a/frontend/src/domains/PRDetail/components/ChatPanel/utils/groupMessages.test.ts
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/utils/groupMessages.test.ts
@@ -144,3 +144,24 @@ describe('groupMessages — stderrChunks', () => {
     expect(toolItem.stderrChunks).toBeUndefined();
   });
 });
+
+const aborted = (id: string): ClaudeMessage => ({
+  id,
+  type: 'aborted',
+  content: '',
+  timestamp: new Date(),
+});
+
+describe('groupMessages — aborted', () => {
+  it('renders an aborted message as a terminal text line', () => {
+    const result = groupMessages([text('1', 'hello'), aborted('2')], false);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ kind: 'text', content: 'hello' });
+    expect(result[1]).toMatchObject({
+      kind: 'text',
+      id: '2',
+      content: 'Stopped by user',
+      isStreaming: false,
+    });
+  });
+});

--- a/frontend/src/domains/PRDetail/components/ChatPanel/utils/groupMessages.ts
+++ b/frontend/src/domains/PRDetail/components/ChatPanel/utils/groupMessages.ts
@@ -87,6 +87,15 @@ export const groupMessages = (
         chunks: [{ id: msg.id, content: `Error: ${msg.content}` }],
         isStreaming: false,
       });
+    } else if (msg.type === 'aborted') {
+      flushText(false);
+      result.push({
+        kind: 'text',
+        id: msg.id,
+        content: 'Stopped by user',
+        chunks: [{ id: msg.id, content: 'Stopped by user' }],
+        isStreaming: false,
+      });
     }
   }
 

--- a/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/types.ts
+++ b/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/types.ts
@@ -33,7 +33,15 @@ export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected';
 
 export interface ClaudeMessage {
   id: string;
-  type: 'text' | 'tool' | 'tool_result' | 'error' | 'stderr' | 'done' | 'user';
+  type:
+    | 'text'
+    | 'tool'
+    | 'tool_result'
+    | 'error'
+    | 'stderr'
+    | 'done'
+    | 'user'
+    | 'aborted';
   content: string;
   toolName?: string;
   toolId?: string;

--- a/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useClaudeWebSocket.ts
+++ b/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useClaudeWebSocket.ts
@@ -83,6 +83,9 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
       const data = JSON.parse(event.data) as WsServerMessage;
 
       switch (data.type) {
+        case 'init':
+          setSessionId(data.sessionId);
+          break;
         case 'text':
           addMessage({ type: 'text', content: data.chunk });
           break;

--- a/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useClaudeWebSocket.ts
+++ b/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useClaudeWebSocket.ts
@@ -70,12 +70,8 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
 
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [activeRequestId, setActiveRequestId] = useState<string | null>(null);
-  const abortPendingRef = useRef(false);
   const activeRequestIdRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    activeRequestIdRef.current = activeRequestId;
-  }, [activeRequestId]);
+  const abortedRequestIdRef = useRef<string | null>(null);
 
   // Wire up message handler
   useEffect(() => {
@@ -109,7 +105,17 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
           appendStderrChunk(data.chunk);
           break;
         case 'error':
-          abortPendingRef.current = false;
+          if (
+            data.requestId &&
+            data.requestId === abortedRequestIdRef.current
+          ) {
+            abortedRequestIdRef.current = null;
+            break;
+          }
+          if (data.requestId && data.requestId !== activeRequestIdRef.current) {
+            break;
+          }
+          activeRequestIdRef.current = null;
           setActiveRequestId(null);
           addMessage({ type: 'error', content: data.message });
           break;
@@ -117,13 +123,15 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
           if (data.sessionId) {
             setSessionId(data.sessionId);
           }
-          setActiveRequestId(null);
-          if (abortPendingRef.current) {
-            abortPendingRef.current = false;
+          if (data.requestId === abortedRequestIdRef.current) {
+            abortedRequestIdRef.current = null;
             addMessage({ type: 'aborted', content: '' });
-          } else {
-            addMessage({ type: 'done', content: '' });
+            break;
           }
+          if (data.requestId !== activeRequestIdRef.current) break;
+          activeRequestIdRef.current = null;
+          setActiveRequestId(null);
+          addMessage({ type: 'done', content: '' });
           break;
         case 'approval_request':
           setApproval({
@@ -191,6 +199,7 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
         });
       }
 
+      activeRequestIdRef.current = requestId;
       setActiveRequestId(requestId);
       return requestId;
     },
@@ -208,7 +217,8 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
     const requestId = activeRequestIdRef.current;
     if (!requestId) return;
     send({ type: 'abort', requestId });
-    abortPendingRef.current = true;
+    abortedRequestIdRef.current = requestId;
+    activeRequestIdRef.current = null;
     setActiveRequestId(null);
   }, [send]);
 

--- a/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useClaudeWebSocket.ts
+++ b/frontend/src/domains/PRDetail/hooks/useClaudeWebSocket/useClaudeWebSocket.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from 'react';
+import { useEffect, useCallback, useState, useRef } from 'react';
 import type {
   WsServerMessage,
   ClaudeExecuteOptions,
@@ -16,6 +16,7 @@ import { useWebSocketApprovals } from './useWebSocketApprovals';
 
 export interface UseClaudeWebSocketReturn {
   status: ConnectionStatus;
+  isStreaming: boolean;
   messages: ClaudeMessage[];
   fileChanges: FileChangesData | null;
   pendingApproval: ApprovalRequest | null;
@@ -29,6 +30,7 @@ export interface UseClaudeWebSocketReturn {
     chatContext?: ClaudeChatContext
   ) => string;
   abort: (requestId: string) => void;
+  stop: () => void;
   respondToApproval: (
     requestId: string,
     approvalRequestId: string,
@@ -67,6 +69,13 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
   } = useWebSocketApprovals(send);
 
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [activeRequestId, setActiveRequestId] = useState<string | null>(null);
+  const abortPendingRef = useRef(false);
+  const activeRequestIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    activeRequestIdRef.current = activeRequestId;
+  }, [activeRequestId]);
 
   // Wire up message handler
   useEffect(() => {
@@ -97,13 +106,21 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
           appendStderrChunk(data.chunk);
           break;
         case 'error':
+          abortPendingRef.current = false;
+          setActiveRequestId(null);
           addMessage({ type: 'error', content: data.message });
           break;
         case 'done':
           if (data.sessionId) {
             setSessionId(data.sessionId);
           }
-          addMessage({ type: 'done', content: '' });
+          setActiveRequestId(null);
+          if (abortPendingRef.current) {
+            abortPendingRef.current = false;
+            addMessage({ type: 'aborted', content: '' });
+          } else {
+            addMessage({ type: 'done', content: '' });
+          }
           break;
         case 'approval_request':
           setApproval({
@@ -171,6 +188,7 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
         });
       }
 
+      setActiveRequestId(requestId);
       return requestId;
     },
     [addMessage, send]
@@ -183,8 +201,17 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
     [send]
   );
 
+  const stop = useCallback(() => {
+    const requestId = activeRequestIdRef.current;
+    if (!requestId) return;
+    send({ type: 'abort', requestId });
+    abortPendingRef.current = true;
+    setActiveRequestId(null);
+  }, [send]);
+
   return {
     status,
+    isStreaming: activeRequestId !== null,
     messages,
     fileChanges,
     pendingApproval,
@@ -193,6 +220,7 @@ export function useClaudeWebSocket(): UseClaudeWebSocketReturn {
     disconnect,
     execute,
     abort,
+    stop,
     respondToApproval,
     respondToPlanApproval,
     clearMessages,


### PR DESCRIPTION
## Summary

- Added a Stop button to the chat follow-up input that aborts the in-flight Claude stream and renders a dedicated `aborted` message in the timeline.
- Wired abort flow end-to-end: frontend `stop()` sends an abort message over WebSocket; backend's `ClaudeProcess` now tracks the aborted state and emits `done` instead of `error` on SIGTERM close, so exit code 143 no longer surfaces as a chat error.
- Captured `sessionId` from the `init` WS event (instead of only `done`) so stopping before completion still leaves the follow-up Send button enabled, and gated the "Thinking..." indicator on `isStreaming` to prevent a stuck spinner when resuming a history session whose last entry is a user message.

## Flow

```mermaid
sequenceDiagram
    participant UI as FollowUpInput
    participant Hook as useClaudeWebSocket
    participant WS as WebSocket
    participant Proc as ClaudeProcess

    UI->>Hook: execute(followUp)
    Hook->>WS: followUp
    WS->>Proc: spawn + sendPrompt
    Proc-->>Hook: init { sessionId }
    Note over Hook: setSessionId early
    UI->>Hook: stop()
    Hook->>WS: abort { requestId }
    WS->>Proc: abort() (aborted = true)
    Proc-->>Hook: done (exitCode 143, no error)
    Note over Hook: render 'aborted' message,<br/>Send button re-enabled
```

## Test plan

- [ ] Start a fresh chat, click Stop mid-stream → chat shows aborted message (no "Process exited with code 143" error), follow-up Send button becomes enabled after typing.
- [ ] Stop a stream, navigate to history, resume the same session → no stuck "Thinking..." spinner.
- [ ] Let a stream complete normally → `done` path still works, no regression in normal completion.