### PR TITLE
feat(frontend): move breadcrumb into AppHeader

### DIFF
--- a/frontend/src/domains/PRDetail/components/PRDetailContent/PRDetailContent.tsx
+++ b/frontend/src/domains/PRDetail/components/PRDetailContent/PRDetailContent.tsx
@@ -63,14 +63,7 @@ export const PRDetailContent = ({ projectId, prNumber, origin, ws }: Props) => {
 
   return (
     <>
-      <PRHeader
-        projectId={projectId}
-        projectName={project.name}
-        prNumber={prNumber}
-        pr={pr}
-        origin={origin}
-        githubBaseUrl={githubBaseUrl}
-      />
+      <PRHeader pr={pr} githubBaseUrl={githubBaseUrl} />
 
       {linkedBody && (
         <PRDescription body={linkedBody} onAskClaude={openPRChat} />

--- a/frontend/src/domains/PRDetail/components/PRHeader/PRHeader.tsx
+++ b/frontend/src/domains/PRDetail/components/PRHeader/PRHeader.tsx
@@ -1,14 +1,9 @@
-import { Link } from 'react-router-dom';
 import { ExternalLink, MessageCircle } from 'lucide-react';
 import { formatDate } from '@/shared/utils';
 import type { PRDetail } from '@lgtmai/backend/types';
 
 interface Props {
-  projectId: string;
-  projectName?: string;
-  prNumber: string;
   pr: PRDetail;
-  origin?: string;
   githubBaseUrl?: string | null;
 }
 
@@ -18,35 +13,13 @@ const statusColors = {
   closed: 'bg-red-100 text-red-800',
 };
 
-export const PRHeader = ({
-  projectId,
-  projectName,
-  prNumber,
-  pr,
-  origin,
-  githubBaseUrl,
-}: Props) => {
+export const PRHeader = ({ pr, githubBaseUrl }: Props) => {
   const statusColor =
     statusColors[pr.state as keyof typeof statusColors] ||
     'bg-gray-100 text-gray-800';
 
   return (
     <header className="mb-8">
-      <div className="mb-4 flex items-center gap-2 text-sm text-gray-500">
-        <Link to="/" className="hover:text-indigo-500">
-          Projects
-        </Link>
-        <span>/</span>
-        <Link
-          to={`/projects/${projectId}/prs${origin ? `?origin=${encodeURIComponent(origin)}` : ''}`}
-          className="hover:text-indigo-500"
-        >
-          {projectName}
-        </Link>
-        <span>/</span>
-        <span className="text-gray-900">PR #{prNumber}</span>
-      </div>
-
       <div className="flex items-start justify-between">
         <div>
           {githubBaseUrl ? (

--- a/frontend/src/domains/PRList/page.tsx
+++ b/frontend/src/domains/PRList/page.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { AsyncBoundary, Select, Spinner, Tabs } from '@/shared/components';
 import { usePRListParams } from './hooks/usePRListParams';
 import { useQuery } from '@tanstack/react-query';
@@ -31,13 +31,6 @@ export const PRListPage = () => {
   return (
     <div className="mx-auto max-w-6xl p-8">
       <header className="mb-8">
-        <div className="mb-4 flex items-center gap-2 text-sm text-gray-500">
-          <Link to="/" className="hover:text-indigo-500">
-            Projects
-          </Link>
-          <span>/</span>
-          <span className="text-gray-900">{project?.name}</span>
-        </div>
         <div className="flex items-center justify-between">
           <h1 className="text-3xl font-bold text-gray-900">Pull Requests</h1>
           <div className="flex items-center gap-3">

--- a/frontend/src/features/AppHeader/AppHeader.tsx
+++ b/frontend/src/features/AppHeader/AppHeader.tsx
@@ -1,12 +1,16 @@
 import { AsyncBoundary } from '@/shared/components';
 import { AccountMenu } from './components/AccountMenu/AccountMenu';
+import { Breadcrumb } from './components/Breadcrumb/Breadcrumb';
 
 export const AppHeader = () => {
   return (
     <header className="fixed z-10 flex h-(--header-height) w-full items-center justify-between border-b border-gray-200 bg-white px-6">
-      <h1 className="bg-gradient-to-r from-indigo-500 to-purple-600 bg-clip-text text-xl font-bold text-transparent">
-        LGTM AI
-      </h1>
+      <div className="flex items-center gap-6">
+        <h1 className="bg-gradient-to-r from-indigo-500 to-purple-600 bg-clip-text text-xl font-bold text-transparent">
+          LGTM AI
+        </h1>
+        <Breadcrumb />
+      </div>
       <AsyncBoundary
         pending={<span className="text-sm text-gray-500">Loading...</span>}
         rejected={({ error, reset }) => (

--- a/frontend/src/features/AppHeader/components/Breadcrumb/Breadcrumb.tsx
+++ b/frontend/src/features/AppHeader/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,46 @@
+import { Link, useMatch, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { getProjectDetailQueryOptions } from '@/queries';
+
+export const Breadcrumb = () => {
+  const prListMatch = useMatch('/projects/:projectId/prs');
+  const prDetailMatch = useMatch('/projects/:projectId/prs/:prNumber');
+  const [searchParams] = useSearchParams();
+
+  const match = prDetailMatch ?? prListMatch;
+  const projectId = match?.params.projectId;
+  const prNumber = prDetailMatch?.params.prNumber;
+
+  const { data: project } = useQuery({
+    ...getProjectDetailQueryOptions(projectId ?? ''),
+    enabled: !!projectId,
+    throwOnError: false,
+  });
+
+  if (!projectId) return null;
+
+  const origin = searchParams.get('origin');
+  const prListTo = `/projects/${projectId}/prs${
+    origin ? `?origin=${encodeURIComponent(origin)}` : ''
+  }`;
+
+  return (
+    <nav className="flex items-center gap-2 text-sm text-gray-500">
+      <Link to="/" className="hover:text-indigo-500">
+        Projects
+      </Link>
+      <span>/</span>
+      {prNumber ? (
+        <>
+          <Link to={prListTo} className="hover:text-indigo-500">
+            {project?.name ?? '...'}
+          </Link>
+          <span>/</span>
+          <span className="text-gray-900">PR #{prNumber}</span>
+        </>
+      ) : (
+        <span className="text-gray-900">{project?.name ?? '...'}</span>
+      )}
+    </nav>
+  );
+};


### PR DESCRIPTION
## Summary

- Centralized breadcrumb navigation in the global `AppHeader`, driven by the current route via `useMatch` + `useSearchParams`.
- Dropped the duplicated breadcrumb blocks from `PRHeader` (PR detail) and the `PRList` page header; `PRHeader` props are now scoped to its actual responsibilities (`pr`, `githubBaseUrl`).
- Breadcrumb link to the PR list preserves the `origin` query param from the current URL so remote selection survives back-navigation.

## Data flow

```mermaid
flowchart LR
    Route[Current route] -->|useMatch| Breadcrumb
    URL[Search params] -->|origin| Breadcrumb
    Breadcrumb -->|getProjectDetail| ReactQuery[(React Query cache)]
    Breadcrumb --> AppHeader
```

Closes #125

## Test plan

- [ ] Navigate / -> /projects/:id/prs -> /projects/:id/prs/:n, breadcrumb updates at each step.
- [ ] On PR detail with `?origin=foo`, clicking the project crumb returns to PR list with `origin=foo` preserved.
- [ ] Page-level headers (PRHeader, PRList) no longer show a breadcrumb.