### PR TITLE
refactor(backend): extract GhGraphQLClient to encapsulate gh CLI GraphQL execution

### DIFF
--- a/backend/modules/projects/gh-graphql.client.test.ts
+++ b/backend/modules/projects/gh-graphql.client.test.ts
@@ -211,7 +211,7 @@ describe('GhGraphQLClient.request', () => {
     await expect(
       client.request('query { node { id } }', {})
     ).rejects.toMatchObject({
-      message: 'Failed to fetch PR data from GitHub',
+      message: 'Failed to fetch data from GitHub',
       statusCode: 500,
     });
   });

--- a/backend/modules/projects/gh-graphql.client.test.ts
+++ b/backend/modules/projects/gh-graphql.client.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockExecAsync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:util', () => ({
+  promisify: () => mockExecAsync,
+}));
+
+const { GhGraphQLClient } = await import('./gh-graphql.client.js');
+
+describe('GhGraphQLClient.request', () => {
+  let client: InstanceType<typeof GhGraphQLClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new GhGraphQLClient();
+  });
+
+  function mockSuccess(data: unknown) {
+    mockExecAsync.mockResolvedValueOnce({
+      stdout: JSON.stringify({ data }),
+      stderr: '',
+    });
+  }
+
+  function ghArgs(): string[] {
+    return mockExecAsync.mock.calls[0][1] as string[];
+  }
+
+  it('passes query string as -f query=... argument', async () => {
+    // given
+    mockSuccess({ repository: null });
+
+    // when
+    await client.request('query { viewer { login } }', {});
+
+    // then
+    const args = ghArgs();
+    expect(args).toContain('-f');
+    expect(args[args.indexOf('-f') + 1]).toBe(
+      'query=query { viewer { login } }'
+    );
+  });
+
+  it('serializes string variable as -f key=value', async () => {
+    // given
+    mockSuccess({});
+
+    // when
+    await client.request(
+      'query Q($owner: String!) { repository(owner: $owner) { id } }',
+      {
+        owner: 'octocat',
+      }
+    );
+
+    // then
+    const args = ghArgs();
+    expect(args).toContain('owner=octocat');
+    const flagIndex = args.indexOf('owner=octocat') - 1;
+    expect(args[flagIndex]).toBe('-f');
+  });
+
+  it('serializes number variable as -F key=value', async () => {
+    // given
+    mockSuccess({});
+
+    // when
+    await client.request('query Q($limit: Int!) { node { id } }', {
+      limit: 50,
+    });
+
+    // then
+    const args = ghArgs();
+    expect(args).toContain('limit=50');
+    const flagIndex = args.indexOf('limit=50') - 1;
+    expect(args[flagIndex]).toBe('-F');
+  });
+
+  it('serializes array variable as repeated -f key[]=value entries', async () => {
+    // given
+    mockSuccess({});
+
+    // when
+    await client.request('query Q($states: [IssueState!]) { node { id } }', {
+      states: ['OPEN', 'CLOSED'],
+    });
+
+    // then
+    const args = ghArgs();
+    const statesArgs = args.filter(
+      (_, i) => args[i - 1] === '-f' && args[i].startsWith('states[]=')
+    );
+    expect(statesArgs).toEqual(['states[]=OPEN', 'states[]=CLOSED']);
+  });
+
+  it('omits undefined variables from arguments', async () => {
+    // given
+    mockSuccess({});
+
+    // when
+    await client.request('query Q($after: String) { node { id } }', {
+      after: undefined,
+      owner: 'octocat',
+    });
+
+    // then
+    const args = ghArgs();
+    expect(args.some((a) => a.startsWith('after='))).toBe(false);
+    expect(args).toContain('owner=octocat');
+  });
+
+  it('returns data from GraphQL response', async () => {
+    // given
+    const payload = { repository: { id: 'R_1', name: 'hello' } };
+    mockSuccess(payload);
+
+    // when
+    const result = await client.request<typeof payload>(
+      'query { node { id } }',
+      {}
+    );
+
+    // then
+    expect(result).toEqual(payload);
+  });
+
+  it('throws BAD_GATEWAY when GraphQL response contains errors', async () => {
+    // given
+    mockExecAsync.mockResolvedValueOnce({
+      stdout: JSON.stringify({ errors: [{ message: 'Field does not exist' }] }),
+      stderr: '',
+    });
+
+    // when / then
+    await expect(
+      client.request('query { node { id } }', {})
+    ).rejects.toMatchObject({
+      message: 'GraphQL query failed: Field does not exist',
+      statusCode: 502,
+    });
+  });
+
+  it('throws BAD_GATEWAY with fallback message when errors array is empty', async () => {
+    // given
+    mockExecAsync.mockResolvedValueOnce({
+      stdout: JSON.stringify({ errors: [] }),
+      stderr: '',
+    });
+
+    // when / then
+    await expect(
+      client.request('query { node { id } }', {})
+    ).rejects.toMatchObject({
+      message: 'GraphQL query failed: Unknown GraphQL error',
+      statusCode: 502,
+    });
+  });
+
+  it('throws BAD_GATEWAY when response has no data field', async () => {
+    // given
+    mockExecAsync.mockResolvedValueOnce({
+      stdout: JSON.stringify({}),
+      stderr: '',
+    });
+
+    // when / then
+    await expect(
+      client.request('query { node { id } }', {})
+    ).rejects.toMatchObject({
+      message: 'GraphQL query failed: Unknown GraphQL error',
+      statusCode: 502,
+    });
+  });
+
+  it('throws SERVICE_UNAVAILABLE when gh CLI reports authentication error', async () => {
+    // given
+    mockExecAsync.mockRejectedValueOnce(
+      new Error('authentication required: gh auth login')
+    );
+
+    // when / then
+    await expect(
+      client.request('query { node { id } }', {})
+    ).rejects.toMatchObject({
+      message:
+        'GitHub CLI is not authenticated. Please check your account in the header.',
+      statusCode: 503,
+    });
+  });
+
+  it('throws FORBIDDEN when gh CLI reports not found', async () => {
+    // given
+    mockExecAsync.mockRejectedValueOnce(new Error('not found'));
+
+    // when / then
+    await expect(
+      client.request('query { node { id } }', {})
+    ).rejects.toMatchObject({
+      message:
+        'Cannot access this repository. Try switching your GitHub account in the header.',
+      statusCode: 403,
+    });
+  });
+
+  it('throws INTERNAL_SERVER_ERROR for unknown gh CLI errors', async () => {
+    // given
+    mockExecAsync.mockRejectedValueOnce(new Error('network timeout'));
+
+    // when / then
+    await expect(
+      client.request('query { node { id } }', {})
+    ).rejects.toMatchObject({
+      message: 'Failed to fetch PR data from GitHub',
+      statusCode: 500,
+    });
+  });
+});

--- a/backend/modules/projects/gh-graphql.client.ts
+++ b/backend/modules/projects/gh-graphql.client.ts
@@ -1,0 +1,51 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { injectable } from 'inversify';
+import HttpStatus from 'http-status';
+import { AppError } from '../../errors/AppError.js';
+import { mapGhError } from './gh.util.js';
+
+const execFileAsync = promisify(execFile);
+
+type GhGraphQLResponse<T> = { data?: T; errors?: { message: string }[] };
+
+type Variables = Record<string, string | number | string[] | undefined>;
+
+@injectable()
+export class GhGraphQLClient {
+  async request<T>(query: string, variables: Variables = {}): Promise<T> {
+    const args = [
+      'api',
+      'graphql',
+      '-f',
+      `query=${query}`,
+      ...this.buildVariableArgs(variables),
+    ];
+
+    const { stdout } = await execFileAsync('gh', args).catch((error) => {
+      throw mapGhError(error, 'fetch');
+    });
+
+    const result = JSON.parse(stdout) as GhGraphQLResponse<T>;
+
+    if (result.errors || !result.data) {
+      const message = result.errors?.[0]?.message ?? 'Unknown GraphQL error';
+      throw new AppError(
+        `GraphQL query failed: ${message}`,
+        HttpStatus.BAD_GATEWAY
+      );
+    }
+
+    return result.data;
+  }
+
+  private buildVariableArgs(variables: Variables): string[] {
+    return Object.entries(variables).flatMap(([key, value]) => {
+      if (value === undefined) return [];
+      if (Array.isArray(value))
+        return value.flatMap((v) => ['-f', `${key}[]=${v}`]);
+      if (typeof value === 'number') return ['-F', `${key}=${value}`];
+      return ['-f', `${key}=${value}`];
+    });
+  }
+}

--- a/backend/modules/projects/gh.util.ts
+++ b/backend/modules/projects/gh.util.ts
@@ -35,7 +35,7 @@ export function mapGhError(error: unknown, context: GhErrorContext): AppError {
       );
     }
     return new AppError(
-      'Failed to fetch PR data from GitHub',
+      'Failed to fetch data from GitHub',
       HttpStatus.INTERNAL_SERVER_ERROR,
       error
     );

--- a/backend/modules/projects/issue-detail.service.test.ts
+++ b/backend/modules/projects/issue-detail.service.test.ts
@@ -1,19 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-const mockExecAsync = vi.hoisted(() => vi.fn());
-
-vi.mock('node:util', () => ({
-  promisify: () => mockExecAsync,
-}));
-
-const { IssueDetailService } = await import('./issue-detail.service.js');
+import { GhGraphQLClient } from './gh-graphql.client.js';
+import { IssueDetailService } from './issue-detail.service.js';
+import { AppError } from '../../errors/AppError.js';
+import HttpStatus from 'http-status';
 
 describe('IssueDetailService.fetchIssueDetail', () => {
-  let service: InstanceType<typeof IssueDetailService>;
+  let mockRequest: ReturnType<typeof vi.fn>;
+  let service: IssueDetailService;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    service = new IssueDetailService();
+    mockRequest = vi.fn();
+    const mockClient = { request: mockRequest } as unknown as GhGraphQLClient;
+    service = new IssueDetailService(mockClient);
   });
 
   const mockIssueNode = {
@@ -52,19 +50,9 @@ describe('IssueDetailService.fetchIssueDetail', () => {
     milestone: { id: 'M_1', title: 'v2.0' },
   };
 
-  const mockIssueDetailData = {
-    data: {
-      repository: {
-        issue: mockIssueNode,
-      },
-    },
-  };
-
   it('returns issue detail with correct shape', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify(mockIssueDetailData),
-    });
+    mockRequest.mockResolvedValue({ repository: { issue: mockIssueNode } });
 
     // when
     const result = await service.fetchIssueDetail('owner/repo', 42);
@@ -83,15 +71,8 @@ describe('IssueDetailService.fetchIssueDetail', () => {
 
   it('returns null milestone when not set', async () => {
     // given
-    const dataWithoutMilestone = {
-      data: {
-        repository: {
-          issue: { ...mockIssueNode, milestone: null },
-        },
-      },
-    };
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify(dataWithoutMilestone),
+    mockRequest.mockResolvedValue({
+      repository: { issue: { ...mockIssueNode, milestone: null } },
     });
 
     // when
@@ -106,128 +87,87 @@ describe('IssueDetailService.fetchIssueDetail', () => {
     await expect(service.fetchIssueDetail('invalid', 1)).rejects.toThrow();
   });
 
-  it('throws AppError when GraphQL response contains errors', async () => {
+  it('throws AppError when client throws GraphQL error', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        errors: [{ message: 'Could not resolve to a Repository' }],
-      }),
-    });
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'GraphQL query failed: Could not resolve to a Repository',
+        HttpStatus.BAD_GATEWAY
+      )
+    );
 
-    // when
-    let error: unknown;
-    try {
-      await service.fetchIssueDetail('owner/repo', 42);
-    } catch (e) {
-      error = e;
-    }
-
-    // then
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain(
+    // when / then
+    await expect(service.fetchIssueDetail('owner/repo', 42)).rejects.toThrow(
       'Could not resolve to a Repository'
     );
   });
 
-  it('throws AppError when GraphQL response has no data', async () => {
-    // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({}),
-    });
-
-    // when
-    let error: unknown;
-    try {
-      await service.fetchIssueDetail('owner/repo', 42);
-    } catch (e) {
-      error = e;
-    }
-
-    // then
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain('Unknown GraphQL error');
-  });
-
   it('throws 404 AppError when issue is null in response', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        data: { repository: { issue: null } },
-      }),
+    mockRequest.mockResolvedValue({ repository: { issue: null } });
+
+    // when / then
+    await expect(
+      service.fetchIssueDetail('owner/repo', 42)
+    ).rejects.toMatchObject({
+      message: 'Issue not found',
+      statusCode: 404,
     });
-
-    // when
-    let error: unknown;
-    try {
-      await service.fetchIssueDetail('owner/repo', 42);
-    } catch (e) {
-      error = e;
-    }
-
-    // then
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe('Issue not found');
-    expect((error as { statusCode?: number }).statusCode).toBe(404);
   });
 
   it('throws authentication AppError when gh CLI is not authenticated', async () => {
     // given
-    mockExecAsync.mockRejectedValue(new Error('authentication failed'));
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'GitHub CLI is not authenticated. Please check your account in the header.',
+        HttpStatus.SERVICE_UNAVAILABLE
+      )
+    );
 
-    // when
-    let error: unknown;
-    try {
-      await service.fetchIssueDetail('owner/repo', 42);
-    } catch (e) {
-      error = e;
-    }
-
-    // then
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain('not authenticated');
-    expect((error as { statusCode?: number }).statusCode).toBe(503);
+    // when / then
+    await expect(
+      service.fetchIssueDetail('owner/repo', 42)
+    ).rejects.toMatchObject({
+      message:
+        'GitHub CLI is not authenticated. Please check your account in the header.',
+      statusCode: 503,
+    });
   });
 
   it('throws 403 AppError when repository is not found', async () => {
     // given
-    mockExecAsync.mockRejectedValue(
-      new Error('could not resolve to a repository')
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'Cannot access this repository. Try switching your GitHub account in the header.',
+        HttpStatus.FORBIDDEN
+      )
     );
 
-    // when
-    let error: unknown;
-    try {
-      await service.fetchIssueDetail('owner/repo', 42);
-    } catch (e) {
-      error = e;
-    }
-
-    // then
-    expect((error as { statusCode?: number }).statusCode).toBe(403);
+    // when / then
+    await expect(
+      service.fetchIssueDetail('owner/repo', 42)
+    ).rejects.toMatchObject({ statusCode: 403 });
   });
 
   it('throws 500 AppError on unknown gh CLI error', async () => {
     // given
-    mockExecAsync.mockRejectedValue(new Error('network timeout'));
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'Failed to fetch PR data from GitHub',
+        HttpStatus.INTERNAL_SERVER_ERROR
+      )
+    );
 
-    // when
-    let error: unknown;
-    try {
-      await service.fetchIssueDetail('owner/repo', 42);
-    } catch (e) {
-      error = e;
-    }
-
-    // then
-    expect((error as { statusCode?: number }).statusCode).toBe(500);
+    // when / then
+    await expect(
+      service.fetchIssueDetail('owner/repo', 42)
+    ).rejects.toMatchObject({ statusCode: 500 });
   });
 
   it('falls back to empty string when issue body is null', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        data: { repository: { issue: { ...mockIssueNode, body: null } } },
-      }),
+    mockRequest.mockResolvedValue({
+      repository: { issue: { ...mockIssueNode, body: null } },
     });
 
     // when
@@ -239,20 +179,16 @@ describe('IssueDetailService.fetchIssueDetail', () => {
 
   it('falls back to login when author name is missing', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        data: {
-          repository: {
-            issue: {
-              ...mockIssueNode,
-              author: {
-                login: 'author1',
-                avatarUrl: 'https://avatars.githubusercontent.com/u/2',
-              },
-            },
+    mockRequest.mockResolvedValue({
+      repository: {
+        issue: {
+          ...mockIssueNode,
+          author: {
+            login: 'author1',
+            avatarUrl: 'https://avatars.githubusercontent.com/u/2',
           },
         },
-      }),
+      },
     });
 
     // when
@@ -264,21 +200,17 @@ describe('IssueDetailService.fetchIssueDetail', () => {
 
   it('sets is_bot true when author typename is Bot', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        data: {
-          repository: {
-            issue: {
-              ...mockIssueNode,
-              author: {
-                __typename: 'Bot',
-                login: 'dependabot',
-                avatarUrl: 'https://avatars.githubusercontent.com/u/27347476',
-              },
-            },
+    mockRequest.mockResolvedValue({
+      repository: {
+        issue: {
+          ...mockIssueNode,
+          author: {
+            __typename: 'Bot',
+            login: 'dependabot',
+            avatarUrl: 'https://avatars.githubusercontent.com/u/27347476',
           },
         },
-      }),
+      },
     });
 
     // when
@@ -290,14 +222,13 @@ describe('IssueDetailService.fetchIssueDetail', () => {
 
   it('falls back to commentNodes length when totalCount is missing', async () => {
     // given
-    const issueWithoutTotalCount = {
-      ...mockIssueNode,
-      comments: { nodes: mockIssueNode.comments.nodes },
-    };
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        data: { repository: { issue: issueWithoutTotalCount } },
-      }),
+    mockRequest.mockResolvedValue({
+      repository: {
+        issue: {
+          ...mockIssueNode,
+          comments: { nodes: mockIssueNode.comments.nodes },
+        },
+      },
     });
 
     // when
@@ -309,19 +240,15 @@ describe('IssueDetailService.fetchIssueDetail', () => {
 
   it('returns empty arrays when assignees, labels, and comment nodes are null', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        data: {
-          repository: {
-            issue: {
-              ...mockIssueNode,
-              assignees: { nodes: null },
-              labels: { nodes: null },
-              comments: { nodes: null },
-            },
-          },
+    mockRequest.mockResolvedValue({
+      repository: {
+        issue: {
+          ...mockIssueNode,
+          assignees: { nodes: null },
+          labels: { nodes: null },
+          comments: { nodes: null },
         },
-      }),
+      },
     });
 
     // when

--- a/backend/modules/projects/issue-detail.service.ts
+++ b/backend/modules/projects/issue-detail.service.ts
@@ -1,20 +1,19 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import HttpStatus from 'http-status';
 import type { IssueDetail } from '../../types/issues.js';
 import type { IssueDetailQuery } from '../../graphql/generated/graphql.js';
 import issueDetailGql from '../../graphql/queries/issue-detail.gql';
 import { IssueDetailDto } from './dto/issue-detail.dto.js';
-import { validateRepoOwnerName, mapGhError } from './gh.util.js';
+import { validateRepoOwnerName } from './gh.util.js';
 import { AppError } from '../../errors/AppError.js';
-
-const execFileAsync = promisify(execFile);
-
-type GhGraphQLResponse<T> = { data?: T; errors?: { message: string }[] };
+import { GhGraphQLClient } from './gh-graphql.client.js';
 
 @injectable()
 export class IssueDetailService {
+  constructor(
+    @inject(GhGraphQLClient) private readonly client: GhGraphQLClient
+  ) {}
+
   async fetchIssueDetail(
     repoOwnerName: string,
     issueNumber: number
@@ -22,45 +21,18 @@ export class IssueDetailService {
     validateRepoOwnerName(repoOwnerName);
 
     const [owner, name] = repoOwnerName.split('/');
-    const result = await this.queryIssueDetail(owner, name, issueNumber);
 
-    if (result.errors || !result.data) {
-      const message = result.errors?.[0]?.message ?? 'Unknown GraphQL error';
-      throw new AppError(
-        `GraphQL issue detail query failed for ${owner}/${name}#${issueNumber}: ${message}`,
-        HttpStatus.INTERNAL_SERVER_ERROR
-      );
-    }
+    const data = await this.client.request<IssueDetailQuery>(issueDetailGql, {
+      owner,
+      name,
+      number: issueNumber,
+    });
 
-    const issue = result.data.repository?.issue;
+    const issue = data.repository?.issue;
     if (!issue) {
       throw new AppError('Issue not found', HttpStatus.NOT_FOUND);
     }
 
     return IssueDetailDto.fromGraphQL(issue);
-  }
-
-  private async queryIssueDetail(
-    owner: string,
-    name: string,
-    issueNumber: number
-  ): Promise<GhGraphQLResponse<IssueDetailQuery>> {
-    try {
-      const { stdout } = await execFileAsync('gh', [
-        'api',
-        'graphql',
-        '-f',
-        `query=${issueDetailGql}`,
-        '-f',
-        `owner=${owner}`,
-        '-f',
-        `name=${name}`,
-        '-F',
-        `number=${issueNumber}`,
-      ]);
-      return JSON.parse(stdout) as GhGraphQLResponse<IssueDetailQuery>;
-    } catch (error) {
-      throw mapGhError(error, 'fetch');
-    }
   }
 }

--- a/backend/modules/projects/issue-list.service.test.ts
+++ b/backend/modules/projects/issue-list.service.test.ts
@@ -1,20 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { IssueListItem } from '../../types/issues.js';
-
-const mockExecAsync = vi.hoisted(() => vi.fn());
-
-vi.mock('node:util', () => ({
-  promisify: () => mockExecAsync,
-}));
-
-const { IssueListService } = await import('./issue-list.service.js');
+import { GhGraphQLClient } from './gh-graphql.client.js';
+import { IssueListService } from './issue-list.service.js';
+import { AppError } from '../../errors/AppError.js';
+import HttpStatus from 'http-status';
 
 describe('IssueListService.fetchIssueList', () => {
-  let service: InstanceType<typeof IssueListService>;
+  let mockRequest: ReturnType<typeof vi.fn>;
+  let service: IssueListService;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    service = new IssueListService();
+    mockRequest = vi.fn();
+    const mockClient = { request: mockRequest } as unknown as GhGraphQLClient;
+    service = new IssueListService(mockClient);
   });
 
   const mockIssueNodes = [
@@ -37,20 +35,21 @@ describe('IssueListService.fetchIssueList', () => {
     },
   ];
 
-  const mockResponse = {
-    data: {
-      repository: {
-        issues: {
-          totalCount: 1,
-          nodes: mockIssueNodes,
-        },
-      },
-    },
-  };
+  function mockListResponse(totalCount: number, nodes = mockIssueNodes) {
+    mockRequest.mockResolvedValueOnce({
+      repository: { issues: { totalCount, nodes } },
+    });
+  }
+
+  function mockCursorResponse(endCursor: string | null) {
+    mockRequest.mockResolvedValueOnce({
+      repository: { issues: { pageInfo: { endCursor } } },
+    });
+  }
 
   it('returns issue list with correct shape', async () => {
     // given
-    mockExecAsync.mockResolvedValue({ stdout: JSON.stringify(mockResponse) });
+    mockListResponse(1);
 
     // when
     const result = await service.fetchIssueList('owner/repo', {
@@ -81,13 +80,7 @@ describe('IssueListService.fetchIssueList', () => {
 
   it('calculates lastPage correctly', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        data: {
-          repository: { issues: { totalCount: 250, nodes: mockIssueNodes } },
-        },
-      }),
-    });
+    mockListResponse(250);
 
     // when
     const result = await service.fetchIssueList('owner/repo', { limit: 100 });
@@ -96,36 +89,38 @@ describe('IssueListService.fetchIssueList', () => {
     expect(result.lastPage).toBe(3);
   });
 
-  it('passes OPEN state to gh CLI for open filter', async () => {
+  it('passes OPEN state to client for open filter', async () => {
     // given
-    mockExecAsync.mockResolvedValue({ stdout: JSON.stringify(mockResponse) });
+    mockListResponse(1);
 
     // when
     await service.fetchIssueList('owner/repo', { state: 'open' });
 
     // then
-    const args = mockExecAsync.mock.calls[0][1] as string[];
-    expect(args).toContain('states[]=OPEN');
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ states: ['OPEN'] })
+    );
   });
 
-  it('passes CLOSED state to gh CLI for closed filter', async () => {
+  it('passes CLOSED state to client for closed filter', async () => {
     // given
-    mockExecAsync.mockResolvedValue({ stdout: JSON.stringify(mockResponse) });
+    mockListResponse(1);
 
     // when
     await service.fetchIssueList('owner/repo', { state: 'closed' });
 
     // then
-    const args = mockExecAsync.mock.calls[0][1] as string[];
-    expect(args).toContain('states[]=CLOSED');
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ states: ['CLOSED'] })
+    );
   });
 
   it('returns empty items when GraphQL returns null nodes', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        data: { repository: { issues: { totalCount: 0, nodes: null } } },
-      }),
+    mockRequest.mockResolvedValueOnce({
+      repository: { issues: { totalCount: 0, nodes: null } },
     });
 
     // when
@@ -143,19 +138,8 @@ describe('IssueListService.fetchIssueList', () => {
 
   it('fetches page 2 by resolving cursor first', async () => {
     // given
-    const cursorResponse = {
-      data: {
-        repository: {
-          issues: {
-            pageInfo: { endCursor: 'cursor_abc' },
-          },
-        },
-      },
-    };
-
-    mockExecAsync
-      .mockResolvedValueOnce({ stdout: JSON.stringify(cursorResponse) })
-      .mockResolvedValueOnce({ stdout: JSON.stringify(mockResponse) });
+    mockCursorResponse('cursor_abc');
+    mockListResponse(1);
 
     // when
     const result = await service.fetchIssueList('owner/repo', {
@@ -164,31 +148,23 @@ describe('IssueListService.fetchIssueList', () => {
     });
 
     // then
-    expect(mockExecAsync).toHaveBeenCalledTimes(2);
-    const cursorArgs = mockExecAsync.mock.calls[0][1] as string[];
-    expect(cursorArgs).toContain('skip=10');
-
-    const listArgs = mockExecAsync.mock.calls[1][1] as string[];
-    expect(listArgs).toContain('after=cursor_abc');
-
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect(mockRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.objectContaining({ skip: 10 })
+    );
+    expect(mockRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.objectContaining({ after: 'cursor_abc' })
+    );
     expect(result.items).toHaveLength(1);
   });
 
   it('returns empty items when cursor hop returns null (page exceeds total)', async () => {
     // given
-    const emptyCursorResponse = {
-      data: {
-        repository: {
-          issues: {
-            pageInfo: { endCursor: null },
-          },
-        },
-      },
-    };
-
-    mockExecAsync.mockResolvedValueOnce({
-      stdout: JSON.stringify(emptyCursorResponse),
-    });
+    mockCursorResponse(null);
 
     // when
     const result = await service.fetchIssueList('owner/repo', {
@@ -201,29 +177,24 @@ describe('IssueListService.fetchIssueList', () => {
     expect(result.lastPage).toBe(1);
   });
 
-  it('throws BAD_GATEWAY when GraphQL response contains errors', async () => {
+  it('throws BAD_GATEWAY when client throws GraphQL error', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        errors: [{ message: 'Some GraphQL error' }],
-      }),
-    });
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'GraphQL query failed: Some GraphQL error',
+        HttpStatus.BAD_GATEWAY
+      )
+    );
 
     // when / then
     await expect(service.fetchIssueList('owner/repo')).rejects.toMatchObject({
-      message:
-        'GraphQL issue list query failed for owner/repo: Some GraphQL error',
       statusCode: 502,
     });
   });
 
   it('throws BAD_GATEWAY when GraphQL response has no repository', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        data: { repository: null },
-      }),
-    });
+    mockRequest.mockResolvedValueOnce({ repository: null });
 
     // when / then
     await expect(service.fetchIssueList('owner/repo')).rejects.toMatchObject({
@@ -235,69 +206,66 @@ describe('IssueListService.fetchIssueList', () => {
 
   it('maps authentication error to AppError with 503', async () => {
     // given
-    mockExecAsync.mockRejectedValue(new Error('authentication required'));
-
-    const { AppError } = await import('../../errors/AppError.js');
-    type AppErrorInstance = InstanceType<typeof AppError>;
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'GitHub CLI is not authenticated. Please check your account in the header.',
+        HttpStatus.SERVICE_UNAVAILABLE
+      )
+    );
 
     // when / then
-    try {
-      await service.fetchIssueList('owner/repo');
-    } catch (err) {
-      expect(err).toBeInstanceOf(AppError);
-      expect((err as AppErrorInstance).statusCode).toBe(503);
-    }
+    await expect(service.fetchIssueList('owner/repo')).rejects.toMatchObject({
+      statusCode: 503,
+    });
   });
 
   it('maps not found error to 403 AppError', async () => {
     // given
-    mockExecAsync.mockRejectedValue(new Error('not found'));
-
-    const { AppError } = await import('../../errors/AppError.js');
-    type AppErrorInstance = InstanceType<typeof AppError>;
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'Cannot access this repository. Try switching your GitHub account in the header.',
+        HttpStatus.FORBIDDEN
+      )
+    );
 
     // when / then
-    try {
-      await service.fetchIssueList('owner/repo');
-    } catch (err) {
-      expect(err).toBeInstanceOf(AppError);
-      expect((err as AppErrorInstance).statusCode).toBe(403);
-    }
+    await expect(service.fetchIssueList('owner/repo')).rejects.toMatchObject({
+      statusCode: 403,
+    });
   });
 
   it('defaults to open state when given an invalid state value', async () => {
     // given
-    mockExecAsync.mockResolvedValue({ stdout: JSON.stringify(mockResponse) });
+    mockListResponse(1);
 
     // when
-    await service.fetchIssueList('owner/repo', {
-      state: 'invalid' as never,
-    });
+    await service.fetchIssueList('owner/repo', { state: 'invalid' as never });
 
     // then
-    const args = mockExecAsync.mock.calls[0][1] as string[];
-    expect(args).toContain('states[]=OPEN');
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ states: ['OPEN'] })
+    );
   });
 
   it('handles null author and null body fields in GraphQL node', async () => {
     // given
-    const nodeWithNulls = {
-      ...mockIssueNodes[0],
-      body: null,
-      author: null,
-      assignees: { nodes: [] },
-      labels: { nodes: [] },
-      comments: { totalCount: 0 },
-    };
-
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({
-        data: {
-          repository: {
-            issues: { totalCount: 1, nodes: [nodeWithNulls] },
-          },
+    mockRequest.mockResolvedValueOnce({
+      repository: {
+        issues: {
+          totalCount: 1,
+          nodes: [
+            {
+              ...mockIssueNodes[0],
+              body: null,
+              author: null,
+              assignees: { nodes: [] },
+              labels: { nodes: [] },
+              comments: { totalCount: 0 },
+            },
+          ],
         },
-      }),
+      },
     });
 
     // when

--- a/backend/modules/projects/issue-list.service.ts
+++ b/backend/modules/projects/issue-list.service.ts
@@ -1,6 +1,4 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import { normalizePage, normalizeLimit } from './pagination.util.js';
 import type {
   PaginatedIssueList,
@@ -14,11 +12,10 @@ import type {
 import issueListGql from '../../graphql/queries/issue-list.gql';
 import issueCursorGql from '../../graphql/queries/issue-cursor.gql';
 import { IssueListItemDto } from './dto/issue-list.dto.js';
-import { validateRepoOwnerName, mapGhError } from './gh.util.js';
+import { validateRepoOwnerName } from './gh.util.js';
 import { AppError } from '../../errors/AppError.js';
+import { GhGraphQLClient } from './gh-graphql.client.js';
 import HttpStatus from 'http-status';
-
-const execFileAsync = promisify(execFile);
 
 const MAX_GRAPHQL_FIRST = 100;
 
@@ -29,10 +26,12 @@ const GRAPHQL_ISSUE_STATES: Record<IssueState, string[]> = {
   closed: ['CLOSED'],
 };
 
-type GhGraphQLResponse<T> = { data?: T; errors?: { message: string }[] };
-
 @injectable()
 export class IssueListService {
+  constructor(
+    @inject(GhGraphQLClient) private readonly client: GhGraphQLClient
+  ) {}
+
   async fetchIssueList(
     repoOwnerName: string,
     options: { page?: number; limit?: number; state?: IssueState } = {}
@@ -88,33 +87,15 @@ export class IssueListService {
     hop: number,
     after: string | null
   ): Promise<string | null> {
-    const { stdout } = await execFileAsync('gh', [
-      'api',
-      'graphql',
-      '-f',
-      `query=${issueCursorGql}`,
-      '-f',
-      `owner=${owner}`,
-      '-f',
-      `name=${name}`,
-      '-F',
-      `skip=${hop}`,
-      ...this.buildStatesFilterArgs(state),
-      ...(after ? ['-f', `after=${after}`] : []),
-    ]).catch((error) => {
-      throw mapGhError(error, 'fetch');
+    const data = await this.client.request<IssueCursorQuery>(issueCursorGql, {
+      owner,
+      name,
+      skip: hop,
+      states: GRAPHQL_ISSUE_STATES[state],
+      after: after ?? undefined,
     });
-    const result = JSON.parse(stdout) as GhGraphQLResponse<IssueCursorQuery>;
 
-    if (result.errors || !result.data) {
-      const message = result.errors?.[0]?.message ?? 'Unknown GraphQL error';
-      throw new AppError(
-        `GraphQL cursor query failed for ${owner}/${name}: ${message}`,
-        HttpStatus.BAD_GATEWAY
-      );
-    }
-
-    return result.data.repository?.issues.pageInfo.endCursor ?? null;
+    return data.repository?.issues.pageInfo.endCursor ?? null;
   }
 
   private async fetchIssueListGraphQL(
@@ -125,38 +106,21 @@ export class IssueListService {
   ): Promise<{ totalCount: number; items: IssueListItem[] }> {
     const [owner, name] = repoOwnerName.split('/');
 
-    const { stdout } = await execFileAsync('gh', [
-      'api',
-      'graphql',
-      '-f',
-      `query=${issueListGql}`,
-      '-f',
-      `owner=${owner}`,
-      '-f',
-      `name=${name}`,
-      '-F',
-      `limit=${limit}`,
-      ...this.buildStatesFilterArgs(state),
-      ...(cursor ? ['-f', `after=${cursor}`] : []),
-    ]).catch((error) => {
-      throw mapGhError(error, 'fetch');
+    const data = await this.client.request<IssueListQuery>(issueListGql, {
+      owner,
+      name,
+      limit,
+      states: GRAPHQL_ISSUE_STATES[state],
+      after: cursor ?? undefined,
     });
-    const result = JSON.parse(stdout) as GhGraphQLResponse<IssueListQuery>;
 
-    if (result.errors || !result.data) {
-      const message = result.errors?.[0]?.message ?? 'Unknown GraphQL error';
-      throw new AppError(
-        `GraphQL issue list query failed for ${repoOwnerName}: ${message}`,
-        HttpStatus.BAD_GATEWAY
-      );
-    }
-
-    const issues = result.data.repository?.issues;
-    if (!issues)
+    const issues = data.repository?.issues;
+    if (!issues) {
       throw new AppError(
         `GraphQL query failed: repository ${repoOwnerName} not found or issues inaccessible`,
         HttpStatus.BAD_GATEWAY
       );
+    }
 
     return {
       totalCount: issues.totalCount,
@@ -171,9 +135,5 @@ export class IssueListService {
       return state as IssueState;
     }
     return 'open';
-  }
-
-  private buildStatesFilterArgs(state: IssueState): string[] {
-    return GRAPHQL_ISSUE_STATES[state].flatMap((s) => ['-f', `states[]=${s}`]);
   }
 }

--- a/backend/modules/projects/pr-detail.service.test.ts
+++ b/backend/modules/projects/pr-detail.service.test.ts
@@ -1,94 +1,92 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-const mockExecAsync = vi.hoisted(() => vi.fn());
-
-vi.mock('node:util', () => ({
-  promisify: () => mockExecAsync,
-}));
-
-const { PRDetailService } = await import('./pr-detail.service.js');
-
-const makePRNode = (overrides: Record<string, unknown> = {}) => ({
-  number: 1,
-  title: 'Test PR',
-  body: 'Test body',
-  state: 'OPEN',
-  baseRefName: 'main',
-  headRefName: 'feature/test',
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-01-02T00:00:00Z',
-  totalCommentsCount: 0,
-  assignees: { nodes: [{ id: 'U_1', login: 'user1', name: 'User One' }] },
-  author: {
-    __typename: 'User',
-    id: 'U_2',
-    login: 'author1',
-    name: 'Author One',
-    avatarUrl: 'https://avatars.githubusercontent.com/u/2',
-  },
-  comments: { nodes: [] },
-  reviews: { nodes: [] },
-  commits: { nodes: [] },
-  ...overrides,
-});
-
-const makeGraphQLResponse = (prNode: Record<string, unknown>) => ({
-  data: { repository: { pullRequest: prNode } },
-});
-
-const makeAuthor = (overrides: Record<string, unknown> = {}) => ({
-  __typename: 'User',
-  id: 'U_0',
-  login: 'user0',
-  name: 'User Zero',
-  avatarUrl: '',
-  ...overrides,
-});
-
-const makeReviewCommentNode = (overrides: Record<string, unknown> = {}) => ({
-  id: 'PRRC_0',
-  replyTo: null,
-  author: makeAuthor(),
-  body: '',
-  path: 'a.ts',
-  diffHunk: '@@ -1 +1 @@',
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-01-01T00:00:00Z',
-  ...overrides,
-});
-
-const makeReviewNode = (overrides: Record<string, unknown> = {}) => ({
-  id: 'PRR_0',
-  author: makeAuthor(),
-  state: 'COMMENTED',
-  body: '',
-  submittedAt: '2024-01-01T00:00:00Z',
-  comments: { nodes: [] },
-  ...overrides,
-});
-
-const makeIssueCommentNode = (overrides: Record<string, unknown> = {}) => ({
-  id: 'IC_0',
-  author: makeAuthor(),
-  body: '',
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-01-01T00:00:00Z',
-  ...overrides,
-});
+import { GhGraphQLClient } from './gh-graphql.client.js';
+import { PRDetailService } from './pr-detail.service.js';
+import { AppError } from '../../errors/AppError.js';
+import HttpStatus from 'http-status';
 
 describe('PRDetailService.fetchPRDetail', () => {
-  let service: InstanceType<typeof PRDetailService>;
+  let mockRequest: ReturnType<typeof vi.fn>;
+  let service: PRDetailService;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    service = new PRDetailService();
+    mockRequest = vi.fn();
+    const mockClient = { request: mockRequest } as unknown as GhGraphQLClient;
+    service = new PRDetailService(mockClient);
   });
+
+  const makePRNode = (overrides: Record<string, unknown> = {}) => ({
+    number: 1,
+    title: 'Test PR',
+    body: 'Test body',
+    state: 'OPEN',
+    baseRefName: 'main',
+    headRefName: 'feature/test',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-02T00:00:00Z',
+    totalCommentsCount: 0,
+    assignees: { nodes: [{ id: 'U_1', login: 'user1', name: 'User One' }] },
+    author: {
+      __typename: 'User',
+      id: 'U_2',
+      login: 'author1',
+      name: 'Author One',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/2',
+    },
+    comments: { nodes: [] },
+    reviews: { nodes: [] },
+    commits: { nodes: [] },
+    ...overrides,
+  });
+
+  const makeAuthor = (overrides: Record<string, unknown> = {}) => ({
+    __typename: 'User',
+    id: 'U_0',
+    login: 'user0',
+    name: 'User Zero',
+    avatarUrl: '',
+    ...overrides,
+  });
+
+  const makeReviewCommentNode = (overrides: Record<string, unknown> = {}) => ({
+    id: 'PRRC_0',
+    replyTo: null,
+    author: makeAuthor(),
+    body: '',
+    path: 'a.ts',
+    diffHunk: '@@ -1 +1 @@',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  });
+
+  const makeReviewNode = (overrides: Record<string, unknown> = {}) => ({
+    id: 'PRR_0',
+    author: makeAuthor(),
+    state: 'COMMENTED',
+    body: '',
+    submittedAt: '2024-01-01T00:00:00Z',
+    comments: { nodes: [] },
+    ...overrides,
+  });
+
+  const makeIssueCommentNode = (overrides: Record<string, unknown> = {}) => ({
+    id: 'IC_0',
+    author: makeAuthor(),
+    body: '',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  });
+
+  function mockPRResponse(prNode: Record<string, unknown>) {
+    mockRequest.mockResolvedValue({
+      repository: { pullRequest: prNode },
+    });
+  }
 
   it('returns basic PR detail from GraphQL response', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify(makeGraphQLResponse(makePRNode())),
-    });
+    mockPRResponse(makePRNode());
 
     // when
     const result = await service.fetchPRDetail('owner/repo', 1);
@@ -99,18 +97,10 @@ describe('PRDetailService.fetchPRDetail', () => {
     expect(result.baseBranch).toBe('main');
     expect(result.headBranch).toBe('feature/test');
     expect(result.state).toBe('OPEN');
-    expect(mockExecAsync).toHaveBeenCalledWith('gh', [
-      'api',
-      'graphql',
-      '-f',
-      expect.stringContaining('query='),
-      '-f',
-      'owner=owner',
-      '-f',
-      'name=repo',
-      '-F',
-      'number=1',
-    ]);
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ owner: 'owner', name: 'repo', number: 1 })
+    );
   });
 
   it('includes inline comments nested inside reviews', async () => {
@@ -121,33 +111,32 @@ describe('PRDetailService.fetchPRDetail', () => {
       name: 'Reviewer One',
       avatarUrl: 'https://avatars.githubusercontent.com/u/3',
     });
-    const prNode = makePRNode({
-      reviews: {
-        nodes: [
-          makeReviewNode({
-            id: 'PRR_1',
-            author: reviewer,
-            submittedAt: '2024-01-01T11:00:00Z',
-            comments: {
-              nodes: [
-                makeReviewCommentNode({
-                  id: 'PRRC_1',
-                  author: reviewer,
-                  body: 'Nit: rename this variable.',
-                  path: 'src/index.ts',
-                  diffHunk: '@@ -1,3 +1,4 @@',
-                  createdAt: '2024-01-01T11:00:00Z',
-                  updatedAt: '2024-01-01T11:00:00Z',
-                }),
-              ],
-            },
-          }),
-        ],
-      },
-    });
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify(makeGraphQLResponse(prNode)),
-    });
+    mockPRResponse(
+      makePRNode({
+        reviews: {
+          nodes: [
+            makeReviewNode({
+              id: 'PRR_1',
+              author: reviewer,
+              submittedAt: '2024-01-01T11:00:00Z',
+              comments: {
+                nodes: [
+                  makeReviewCommentNode({
+                    id: 'PRRC_1',
+                    author: reviewer,
+                    body: 'Nit: rename this variable.',
+                    path: 'src/index.ts',
+                    diffHunk: '@@ -1,3 +1,4 @@',
+                    createdAt: '2024-01-01T11:00:00Z',
+                    updatedAt: '2024-01-01T11:00:00Z',
+                  }),
+                ],
+              },
+            }),
+          ],
+        },
+      })
+    );
 
     // when
     const result = await service.fetchPRDetail('owner/repo', 1);
@@ -167,29 +156,28 @@ describe('PRDetailService.fetchPRDetail', () => {
 
   it('sets inReplyToId when replyTo is present', async () => {
     // given
-    const prNode = makePRNode({
-      reviews: {
-        nodes: [
-          makeReviewNode({
-            id: 'PRR_1',
-            comments: {
-              nodes: [
-                makeReviewCommentNode({
-                  id: 'PRRC_2',
-                  replyTo: { id: 'PRRC_1' },
-                  body: 'Reply comment',
-                  createdAt: '2024-01-01T12:00:00Z',
-                  updatedAt: '2024-01-01T12:00:00Z',
-                }),
-              ],
-            },
-          }),
-        ],
-      },
-    });
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify(makeGraphQLResponse(prNode)),
-    });
+    mockPRResponse(
+      makePRNode({
+        reviews: {
+          nodes: [
+            makeReviewNode({
+              id: 'PRR_1',
+              comments: {
+                nodes: [
+                  makeReviewCommentNode({
+                    id: 'PRRC_2',
+                    replyTo: { id: 'PRRC_1' },
+                    body: 'Reply comment',
+                    createdAt: '2024-01-01T12:00:00Z',
+                    updatedAt: '2024-01-01T12:00:00Z',
+                  }),
+                ],
+              },
+            }),
+          ],
+        },
+      })
+    );
 
     // when
     const result = await service.fetchPRDetail('owner/repo', 1);
@@ -200,58 +188,57 @@ describe('PRDetailService.fetchPRDetail', () => {
 
   it('totalCommentsCount sums issue comments, inline comments, and non-empty review bodies', async () => {
     // given
-    const prNode = makePRNode({
-      comments: {
-        nodes: [
-          makeIssueCommentNode({
-            id: 'IC_1',
-            body: 'hi',
-            createdAt: '2024-01-01T10:00:00Z',
-            updatedAt: '2024-01-01T10:00:00Z',
-          }),
-          makeIssueCommentNode({
-            id: 'IC_2',
-            body: 'hello',
-            createdAt: '2024-01-01T10:01:00Z',
-            updatedAt: '2024-01-01T10:01:00Z',
-          }),
-        ],
-      },
-      reviews: {
-        nodes: [
-          makeReviewNode({
-            id: 'PRR_1',
-            submittedAt: '2024-01-01T11:00:00Z',
-            comments: {
-              nodes: [
-                makeReviewCommentNode({
-                  id: 'PRRC_1',
-                  body: 'inline 1',
-                  createdAt: '2024-01-01T11:00:00Z',
-                  updatedAt: '2024-01-01T11:00:00Z',
-                }),
-                makeReviewCommentNode({
-                  id: 'PRRC_2',
-                  body: 'inline 2',
-                  diffHunk: '@@ -2 +2 @@',
-                  createdAt: '2024-01-01T11:01:00Z',
-                  updatedAt: '2024-01-01T11:01:00Z',
-                }),
-              ],
-            },
-          }),
-          makeReviewNode({
-            id: 'PRR_2',
-            state: 'APPROVED',
-            body: 'LGTM',
-            submittedAt: '2024-01-01T12:00:00Z',
-          }),
-        ],
-      },
-    });
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify(makeGraphQLResponse(prNode)),
-    });
+    mockPRResponse(
+      makePRNode({
+        comments: {
+          nodes: [
+            makeIssueCommentNode({
+              id: 'IC_1',
+              body: 'hi',
+              createdAt: '2024-01-01T10:00:00Z',
+              updatedAt: '2024-01-01T10:00:00Z',
+            }),
+            makeIssueCommentNode({
+              id: 'IC_2',
+              body: 'hello',
+              createdAt: '2024-01-01T10:01:00Z',
+              updatedAt: '2024-01-01T10:01:00Z',
+            }),
+          ],
+        },
+        reviews: {
+          nodes: [
+            makeReviewNode({
+              id: 'PRR_1',
+              submittedAt: '2024-01-01T11:00:00Z',
+              comments: {
+                nodes: [
+                  makeReviewCommentNode({
+                    id: 'PRRC_1',
+                    body: 'inline 1',
+                    createdAt: '2024-01-01T11:00:00Z',
+                    updatedAt: '2024-01-01T11:00:00Z',
+                  }),
+                  makeReviewCommentNode({
+                    id: 'PRRC_2',
+                    body: 'inline 2',
+                    diffHunk: '@@ -2 +2 @@',
+                    createdAt: '2024-01-01T11:01:00Z',
+                    updatedAt: '2024-01-01T11:01:00Z',
+                  }),
+                ],
+              },
+            }),
+            makeReviewNode({
+              id: 'PRR_2',
+              state: 'APPROVED',
+              body: 'LGTM',
+              submittedAt: '2024-01-01T12:00:00Z',
+            }),
+          ],
+        },
+      })
+    );
 
     // when
     const result = await service.fetchPRDetail('owner/repo', 1);
@@ -262,34 +249,36 @@ describe('PRDetailService.fetchPRDetail', () => {
 
   it('throws NOT_FOUND when PR does not exist in GraphQL response', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({ data: { repository: { pullRequest: null } } }),
-    });
+    mockRequest.mockResolvedValue({ repository: { pullRequest: null } });
 
     // when / then
     await expect(
       service.fetchPRDetail('owner/repo', 999)
-    ).rejects.toMatchObject({
-      statusCode: 404,
-    });
+    ).rejects.toMatchObject({ statusCode: 404 });
   });
 
-  it('throws INTERNAL_SERVER_ERROR on GraphQL errors field', async () => {
+  it('throws BAD_GATEWAY on GraphQL errors field', async () => {
     // given
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify({ errors: [{ message: 'something went wrong' }] }),
-    });
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'GraphQL query failed: something went wrong',
+        HttpStatus.BAD_GATEWAY
+      )
+    );
 
     // when / then
     await expect(service.fetchPRDetail('owner/repo', 1)).rejects.toMatchObject({
-      statusCode: 500,
+      statusCode: 502,
     });
   });
 
   it('throws FORBIDDEN error when PR could not be resolved', async () => {
     // given
-    mockExecAsync.mockRejectedValue(
-      new Error('could not resolve to a PullRequest')
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'Cannot access this repository. Try switching your GitHub account in the header.',
+        HttpStatus.FORBIDDEN
+      )
     );
 
     // when / then
@@ -304,8 +293,11 @@ describe('PRDetailService.fetchPRDetail', () => {
 
   it('throws SERVICE_UNAVAILABLE error for authentication failure', async () => {
     // given
-    mockExecAsync.mockRejectedValue(
-      new Error('authentication required: gh auth login')
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'GitHub CLI is not authenticated. Please check your account in the header.',
+        HttpStatus.SERVICE_UNAVAILABLE
+      )
     );
 
     // when / then
@@ -318,7 +310,12 @@ describe('PRDetailService.fetchPRDetail', () => {
 
   it('throws INTERNAL_SERVER_ERROR for general failures', async () => {
     // given
-    mockExecAsync.mockRejectedValue(new Error('Network error'));
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'Failed to fetch PR data from GitHub',
+        HttpStatus.INTERNAL_SERVER_ERROR
+      )
+    );
 
     // when / then
     await expect(service.fetchPRDetail('owner/repo', 1)).rejects.toMatchObject({
@@ -329,37 +326,40 @@ describe('PRDetailService.fetchPRDetail', () => {
 
   it('maps author login to id and name when id/name are absent', async () => {
     // given
-    const prNode = makePRNode({
-      author: makeAuthor({ login: 'author1', id: undefined, name: undefined }),
-      comments: {
-        nodes: [
-          makeIssueCommentNode({
-            id: 'IC_1',
-            author: makeAuthor({
-              login: 'commenter1',
-              id: undefined,
-              name: undefined,
+    mockPRResponse(
+      makePRNode({
+        author: makeAuthor({
+          login: 'author1',
+          id: undefined,
+          name: undefined,
+        }),
+        comments: {
+          nodes: [
+            makeIssueCommentNode({
+              id: 'IC_1',
+              author: makeAuthor({
+                login: 'commenter1',
+                id: undefined,
+                name: undefined,
+              }),
+              body: 'Nice change!',
             }),
-            body: 'Nice change!',
-          }),
-        ],
-      },
-      reviews: {
-        nodes: [
-          makeReviewNode({
-            id: 'PRR_1',
-            author: makeAuthor({
-              login: 'reviewer1',
-              id: undefined,
-              name: undefined,
+          ],
+        },
+        reviews: {
+          nodes: [
+            makeReviewNode({
+              id: 'PRR_1',
+              author: makeAuthor({
+                login: 'reviewer1',
+                id: undefined,
+                name: undefined,
+              }),
             }),
-          }),
-        ],
-      },
-    });
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify(makeGraphQLResponse(prNode)),
-    });
+          ],
+        },
+      })
+    );
 
     // when
     const result = await service.fetchPRDetail('owner/repo', 1);
@@ -375,17 +375,16 @@ describe('PRDetailService.fetchPRDetail', () => {
 
   it('marks bot authors with is_bot flag', async () => {
     // given
-    const prNode = makePRNode({
-      author: {
-        __typename: 'Bot',
-        id: 'B_1',
-        login: 'dependabot',
-        avatarUrl: 'https://avatars.githubusercontent.com/in/29110',
-      },
-    });
-    mockExecAsync.mockResolvedValue({
-      stdout: JSON.stringify(makeGraphQLResponse(prNode)),
-    });
+    mockPRResponse(
+      makePRNode({
+        author: {
+          __typename: 'Bot',
+          id: 'B_1',
+          login: 'dependabot',
+          avatarUrl: 'https://avatars.githubusercontent.com/in/29110',
+        },
+      })
+    );
 
     // when
     const result = await service.fetchPRDetail('owner/repo', 1);

--- a/backend/modules/projects/pr-detail.service.ts
+++ b/backend/modules/projects/pr-detail.service.ts
@@ -1,20 +1,19 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import HttpStatus from 'http-status';
 import type { PRDetail } from '../../types/pullRequests.js';
 import type { PrDetailQuery } from '../../graphql/generated/graphql.js';
 import prDetailGql from '../../graphql/queries/pr-detail.gql';
 import { PRDetailDto } from './dto/pr-detail.dto.js';
-import { validateRepoOwnerName, mapGhError } from './gh.util.js';
+import { validateRepoOwnerName } from './gh.util.js';
 import { AppError } from '../../errors/AppError.js';
-
-const execFileAsync = promisify(execFile);
-
-type GhGraphQLResponse<T> = { data?: T; errors?: { message: string }[] };
+import { GhGraphQLClient } from './gh-graphql.client.js';
 
 @injectable()
 export class PRDetailService {
+  constructor(
+    @inject(GhGraphQLClient) private readonly client: GhGraphQLClient
+  ) {}
+
   async fetchPRDetail(
     repoOwnerName: string,
     prNumber: number
@@ -22,45 +21,18 @@ export class PRDetailService {
     validateRepoOwnerName(repoOwnerName);
 
     const [owner, name] = repoOwnerName.split('/');
-    const result = await this.queryPRDetail(owner, name, prNumber);
 
-    if (result.errors || !result.data) {
-      const message = result.errors?.[0]?.message ?? 'Unknown GraphQL error';
-      throw new AppError(
-        `GraphQL PR detail query failed for ${owner}/${name}#${prNumber}: ${message}`,
-        HttpStatus.INTERNAL_SERVER_ERROR
-      );
-    }
+    const data = await this.client.request<PrDetailQuery>(prDetailGql, {
+      owner,
+      name,
+      number: prNumber,
+    });
 
-    const pr = result.data.repository?.pullRequest;
+    const pr = data.repository?.pullRequest;
     if (!pr) {
       throw new AppError('PR not found', HttpStatus.NOT_FOUND);
     }
 
     return PRDetailDto.fromGraphQL(pr);
-  }
-
-  private async queryPRDetail(
-    owner: string,
-    name: string,
-    prNumber: number
-  ): Promise<GhGraphQLResponse<PrDetailQuery>> {
-    try {
-      const { stdout } = await execFileAsync('gh', [
-        'api',
-        'graphql',
-        '-f',
-        `query=${prDetailGql}`,
-        '-f',
-        `owner=${owner}`,
-        '-f',
-        `name=${name}`,
-        '-F',
-        `number=${prNumber}`,
-      ]);
-      return JSON.parse(stdout) as GhGraphQLResponse<PrDetailQuery>;
-    } catch (error) {
-      throw mapGhError(error, 'fetch');
-    }
   }
 }

--- a/backend/modules/projects/pr-list.service.test.ts
+++ b/backend/modules/projects/pr-list.service.test.ts
@@ -1,20 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PRListItem } from '../../types/pullRequests.js';
-
-const mockExecAsync = vi.hoisted(() => vi.fn());
-
-vi.mock('node:util', () => ({
-  promisify: () => mockExecAsync,
-}));
-
-const { PRListService } = await import('./pr-list.service.js');
+import { GhGraphQLClient } from './gh-graphql.client.js';
+import { PRListService } from './pr-list.service.js';
+import { AppError } from '../../errors/AppError.js';
+import HttpStatus from 'http-status';
 
 describe('PRListService.fetchPRList', () => {
-  let service: InstanceType<typeof PRListService>;
+  let mockRequest: ReturnType<typeof vi.fn>;
+  let service: PRListService;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    service = new PRListService();
+    mockRequest = vi.fn();
+    const mockClient = { request: mockRequest } as unknown as GhGraphQLClient;
+    service = new PRListService(mockClient);
   });
 
   const mockGraphQLNodes = [
@@ -85,145 +83,95 @@ describe('PRListService.fetchPRList', () => {
     },
   ];
 
-  function mockGraphQLDataResponse(
-    totalCount: number,
-    nodes = mockGraphQLNodes
-  ) {
-    mockExecAsync.mockResolvedValueOnce({
-      stdout: JSON.stringify({
-        data: { repository: { pullRequests: { totalCount, nodes } } },
-      }),
-      stderr: '',
+  function mockListResponse(totalCount: number, nodes = mockGraphQLNodes) {
+    mockRequest.mockResolvedValueOnce({
+      repository: { pullRequests: { totalCount, nodes } },
     });
   }
 
-  function mockGraphQLCursorResponse(endCursor: string) {
-    mockExecAsync.mockResolvedValueOnce({
-      stdout: JSON.stringify({
-        data: { repository: { pullRequests: { pageInfo: { endCursor } } } },
-      }),
-      stderr: '',
+  function mockCursorResponse(endCursor: string) {
+    mockRequest.mockResolvedValueOnce({
+      repository: { pullRequests: { pageInfo: { endCursor } } },
     });
   }
 
   it('should successfully fetch PR list (page 1 — single GraphQL call)', async () => {
     // given
-    mockGraphQLDataResponse(2);
+    mockListResponse(2);
 
     // when
     const result = await service.fetchPRList('owner/repo');
 
     // then
     expect(result).toEqual({ items: mockPRListData, lastPage: 1 });
-    expect(mockExecAsync).toHaveBeenCalledTimes(1);
-    expect(mockExecAsync).toHaveBeenCalledWith('gh', [
-      'api',
-      'graphql',
-      '-f',
-      expect.stringContaining('query='),
-      '-f',
-      'owner=owner',
-      '-f',
-      'name=repo',
-      '-F',
-      'limit=100',
-      '-f',
-      'states[]=OPEN',
-    ]);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        owner: 'owner',
+        name: 'repo',
+        limit: 100,
+        states: ['OPEN'],
+      })
+    );
   });
 
   it('should fetch with cursor for page 2 (two GraphQL calls)', async () => {
     // given
-    mockGraphQLCursorResponse('cursor_abc');
-    mockGraphQLDataResponse(150);
+    mockCursorResponse('cursor_abc');
+    mockListResponse(150);
 
     // when
     await service.fetchPRList('owner/repo', { page: 2, limit: 50 });
 
     // then
-    expect(mockExecAsync).toHaveBeenCalledTimes(2);
-    expect(mockExecAsync).toHaveBeenNthCalledWith(1, 'gh', [
-      'api',
-      'graphql',
-      '-f',
-      expect.stringContaining('query='),
-      '-f',
-      'owner=owner',
-      '-f',
-      'name=repo',
-      '-F',
-      'skip=50',
-      '-f',
-      'states[]=OPEN',
-    ]);
-    expect(mockExecAsync).toHaveBeenNthCalledWith(2, 'gh', [
-      'api',
-      'graphql',
-      '-f',
-      expect.stringContaining('query='),
-      '-f',
-      'owner=owner',
-      '-f',
-      'name=repo',
-      '-F',
-      'limit=50',
-      '-f',
-      'states[]=OPEN',
-      '-f',
-      'after=cursor_abc',
-    ]);
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect(mockRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.objectContaining({ skip: 50, states: ['OPEN'] })
+    );
+    expect(mockRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.objectContaining({
+        limit: 50,
+        states: ['OPEN'],
+        after: 'cursor_abc',
+      })
+    );
   });
 
   it('should hop in chunks of 100 when skip exceeds GitHub GraphQL limit (page=3, limit=100)', async () => {
     // given: skip = (3-1) * 100 = 200, must be fetched in 2 hops of 100 each
-    mockGraphQLCursorResponse('cursor_after_100'); // first hop: first:100, no after
-    mockGraphQLCursorResponse('cursor_after_200'); // second hop: first:100, after:cursor_after_100
-    mockGraphQLDataResponse(300);
+    mockCursorResponse('cursor_after_100');
+    mockCursorResponse('cursor_after_200');
+    mockListResponse(300);
 
     // when
     await service.fetchPRList('owner/repo', { page: 3, limit: 100 });
 
     // then: 2 cursor-resolution calls + 1 data call = 3 total
-    expect(mockExecAsync).toHaveBeenCalledTimes(3);
-
-    // First hop: first:100, no after
-    expect(mockExecAsync).toHaveBeenNthCalledWith(1, 'gh', [
-      'api',
-      'graphql',
-      '-f',
-      expect.stringContaining('query='),
-      '-f',
-      'owner=owner',
-      '-f',
-      'name=repo',
-      '-F',
-      'skip=100',
-      '-f',
-      'states[]=OPEN',
-    ]);
-
-    // Second hop: first:100, after cursor from first hop
-    expect(mockExecAsync).toHaveBeenNthCalledWith(2, 'gh', [
-      'api',
-      'graphql',
-      '-f',
-      expect.stringContaining('query='),
-      '-f',
-      'owner=owner',
-      '-f',
-      'name=repo',
-      '-F',
-      'skip=100',
-      '-f',
-      'states[]=OPEN',
-      '-f',
-      'after=cursor_after_100',
-    ]);
+    expect(mockRequest).toHaveBeenCalledTimes(3);
+    expect(mockRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.objectContaining({ skip: 100, states: ['OPEN'], after: undefined })
+    );
+    expect(mockRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.objectContaining({
+        skip: 100,
+        states: ['OPEN'],
+        after: 'cursor_after_100',
+      })
+    );
   });
 
   it('should calculate lastPage from totalCount', async () => {
     // given
-    mockGraphQLDataResponse(250);
+    mockListResponse(250);
 
     // when
     const result = await service.fetchPRList('owner/repo', { limit: 50 });
@@ -234,7 +182,7 @@ describe('PRListService.fetchPRList', () => {
 
   it('should return lastPage 1 when totalCount is 0', async () => {
     // given
-    mockGraphQLDataResponse(0, []);
+    mockListResponse(0, []);
 
     // when
     const result = await service.fetchPRList('owner/repo');
@@ -245,95 +193,82 @@ describe('PRListService.fetchPRList', () => {
 
   it('should pass state=open via GraphQL states filter', async () => {
     // given
-    mockGraphQLDataResponse(2);
+    mockListResponse(2);
 
     // when
     await service.fetchPRList('owner/repo', { state: 'open' });
 
     // then
-    expect(mockExecAsync).toHaveBeenCalledWith(
-      'gh',
-      expect.arrayContaining(['-f', 'states[]=OPEN'])
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ states: ['OPEN'] })
     );
   });
 
   it('should pass state=closed via GraphQL states filter', async () => {
     // given
-    mockGraphQLDataResponse(2);
+    mockListResponse(2);
 
     // when
     await service.fetchPRList('owner/repo', { state: 'closed' });
 
     // then
-    const args = mockExecAsync.mock.calls[0][1] as string[];
-    const statesArgs = args.filter(
-      (_, i) => args[i - 1] === '-f' && args[i].startsWith('states[]=')
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ states: ['CLOSED', 'MERGED'] })
     );
-    expect(statesArgs).toEqual(['states[]=CLOSED', 'states[]=MERGED']);
   });
 
   it('should pass state=all via GraphQL states filter', async () => {
     // given
-    mockGraphQLDataResponse(2);
+    mockListResponse(2);
 
     // when
     await service.fetchPRList('owner/repo', { state: 'all' });
 
     // then
-    const args = mockExecAsync.mock.calls[0][1] as string[];
-    const statesArgs = args.filter(
-      (_, i) => args[i - 1] === '-f' && args[i].startsWith('states[]=')
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ states: ['OPEN', 'CLOSED', 'MERGED'] })
     );
-    expect(statesArgs).toEqual([
-      'states[]=OPEN',
-      'states[]=CLOSED',
-      'states[]=MERGED',
-    ]);
   });
 
   it('should default to state=open for invalid state value', async () => {
     // given
-    mockGraphQLDataResponse(2);
+    mockListResponse(2);
 
     // when
     await service.fetchPRList('owner/repo', { state: 'invalid' as never });
 
     // then
-    expect(mockExecAsync).toHaveBeenCalledWith(
-      'gh',
-      expect.arrayContaining(['-f', 'states[]=OPEN'])
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ states: ['OPEN'] })
     );
   });
 
   it('should clamp invalid page and limit values', async () => {
     // given
-    mockGraphQLDataResponse(2);
+    mockListResponse(2);
 
     // when
     await service.fetchPRList('owner/repo', { page: 0, limit: 250 });
 
     // then
-    expect(mockExecAsync).toHaveBeenCalledTimes(1);
-    expect(mockExecAsync).toHaveBeenCalledWith('gh', [
-      'api',
-      'graphql',
-      '-f',
-      expect.stringContaining('query='),
-      '-f',
-      'owner=owner',
-      '-f',
-      'name=repo',
-      '-F',
-      'limit=100',
-      '-f',
-      'states[]=OPEN',
-    ]);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ limit: 100 })
+    );
   });
 
   it('should throw SERVICE_UNAVAILABLE error for authentication failure', async () => {
     // given
-    mockExecAsync.mockRejectedValue(
-      new Error('authentication required: gh auth login')
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'GitHub CLI is not authenticated. Please check your account in the header.',
+        HttpStatus.SERVICE_UNAVAILABLE
+      )
     );
 
     // when / then
@@ -346,24 +281,18 @@ describe('PRListService.fetchPRList', () => {
 
   it('should throw FORBIDDEN error for not found', async () => {
     // given
-    mockExecAsync.mockRejectedValue(new Error('Not Found'));
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'Cannot access this repository. Try switching your GitHub account in the header.',
+        HttpStatus.FORBIDDEN
+      )
+    );
 
     // when / then
     await expect(service.fetchPRList('owner/repo')).rejects.toMatchObject({
       message:
         'Cannot access this repository. Try switching your GitHub account in the header.',
       statusCode: 403,
-    });
-  });
-
-  it('should throw INTERNAL_SERVER_ERROR for general failures', async () => {
-    // given
-    mockExecAsync.mockRejectedValue(new Error('Network error'));
-
-    // when / then
-    await expect(service.fetchPRList('owner/repo')).rejects.toMatchObject({
-      message: 'Failed to fetch PR data from GitHub',
-      statusCode: 500,
     });
   });
 
@@ -379,10 +308,12 @@ describe('PRListService.fetchPRList', () => {
 
   it('should throw BAD_GATEWAY when GraphQL response has errors', async () => {
     // given
-    mockExecAsync.mockResolvedValueOnce({
-      stdout: JSON.stringify({ errors: [{ message: 'Field does not exist' }] }),
-      stderr: '',
-    });
+    mockRequest.mockRejectedValue(
+      new AppError(
+        'GraphQL query failed: Field does not exist',
+        HttpStatus.BAD_GATEWAY
+      )
+    );
 
     // when / then
     await expect(service.fetchPRList('owner/repo')).rejects.toMatchObject({
@@ -393,13 +324,8 @@ describe('PRListService.fetchPRList', () => {
 
   it('should return empty result when page is out of bounds (cursor is null)', async () => {
     // given
-    mockExecAsync.mockResolvedValueOnce({
-      stdout: JSON.stringify({
-        data: {
-          repository: { pullRequests: { pageInfo: { endCursor: null } } },
-        },
-      }),
-      stderr: '',
+    mockRequest.mockResolvedValueOnce({
+      repository: { pullRequests: { pageInfo: { endCursor: null } } },
     });
 
     // when
@@ -410,6 +336,6 @@ describe('PRListService.fetchPRList', () => {
 
     // then
     expect(result).toEqual({ items: [], lastPage: 1 });
-    expect(mockExecAsync).toHaveBeenCalledTimes(1);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/modules/projects/pr-list.service.ts
+++ b/backend/modules/projects/pr-list.service.ts
@@ -1,6 +1,4 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import { normalizePage, normalizeLimit } from './pagination.util.js';
 import type {
   PaginatedPRList,
@@ -14,11 +12,10 @@ import type {
 import prListGql from '../../graphql/queries/pr-list.gql';
 import prCursorGql from '../../graphql/queries/pr-cursor.gql';
 import { PRListItemDto } from './dto/pr-list.dto.js';
-import { validateRepoOwnerName, mapGhError } from './gh.util.js';
+import { validateRepoOwnerName } from './gh.util.js';
 import { AppError } from '../../errors/AppError.js';
+import { GhGraphQLClient } from './gh-graphql.client.js';
 import HttpStatus from 'http-status';
-
-const execFileAsync = promisify(execFile);
 
 const MAX_GRAPHQL_FIRST = 100;
 
@@ -30,10 +27,12 @@ const GRAPHQL_PR_STATES: Record<PRState, string[]> = {
   all: ['OPEN', 'CLOSED', 'MERGED'],
 };
 
-type GhGraphQLResponse<T> = { data?: T; errors?: { message: string }[] };
-
 @injectable()
 export class PRListService {
+  constructor(
+    @inject(GhGraphQLClient) private readonly client: GhGraphQLClient
+  ) {}
+
   async fetchPRList(
     repoOwnerName: string,
     options: { page?: number; limit?: number; state?: PRState } = {}
@@ -98,33 +97,15 @@ export class PRListService {
     hop: number,
     after: string | null
   ): Promise<string | null> {
-    const { stdout } = await execFileAsync('gh', [
-      'api',
-      'graphql',
-      '-f',
-      `query=${prCursorGql}`,
-      '-f',
-      `owner=${owner}`,
-      '-f',
-      `name=${name}`,
-      '-F',
-      `skip=${hop}`,
-      ...this.buildStatesFilterArgs(state),
-      ...(after ? ['-f', `after=${after}`] : []),
-    ]).catch((error) => {
-      throw mapGhError(error, 'fetch');
+    const data = await this.client.request<PrCursorQuery>(prCursorGql, {
+      owner,
+      name,
+      skip: hop,
+      states: GRAPHQL_PR_STATES[state],
+      after: after ?? undefined,
     });
-    const result = JSON.parse(stdout) as GhGraphQLResponse<PrCursorQuery>;
 
-    if (result.errors || !result.data) {
-      const message = result.errors?.[0]?.message ?? 'Unknown GraphQL error';
-      throw new AppError(
-        `GraphQL query failed: ${message}`,
-        HttpStatus.BAD_GATEWAY
-      );
-    }
-
-    return result.data.repository?.pullRequests.pageInfo.endCursor ?? null;
+    return data.repository?.pullRequests.pageInfo.endCursor ?? null;
   }
 
   private async fetchPRListGraphQL(
@@ -135,38 +116,21 @@ export class PRListService {
   ): Promise<{ totalCount: number; items: PRListItem[] }> {
     const [owner, name] = repoOwnerName.split('/');
 
-    const { stdout } = await execFileAsync('gh', [
-      'api',
-      'graphql',
-      '-f',
-      `query=${prListGql}`,
-      '-f',
-      `owner=${owner}`,
-      '-f',
-      `name=${name}`,
-      '-F',
-      `limit=${limit}`,
-      ...this.buildStatesFilterArgs(state),
-      ...(cursor ? ['-f', `after=${cursor}`] : []),
-    ]).catch((error) => {
-      throw mapGhError(error, 'fetch');
+    const data = await this.client.request<PrListQuery>(prListGql, {
+      owner,
+      name,
+      limit,
+      states: GRAPHQL_PR_STATES[state],
+      after: cursor ?? undefined,
     });
-    const result = JSON.parse(stdout) as GhGraphQLResponse<PrListQuery>;
 
-    if (result.errors || !result.data) {
-      const message = result.errors?.[0]?.message ?? 'Unknown GraphQL error';
-      throw new AppError(
-        `GraphQL query failed: ${message}`,
-        HttpStatus.BAD_GATEWAY
-      );
-    }
-
-    const prs = result.data.repository?.pullRequests;
-    if (!prs)
+    const prs = data.repository?.pullRequests;
+    if (!prs) {
       throw new AppError(
         'GraphQL query failed: no data',
         HttpStatus.BAD_GATEWAY
       );
+    }
 
     return {
       totalCount: prs.totalCount,
@@ -181,9 +145,5 @@ export class PRListService {
       return state as PRState;
     }
     return 'open';
-  }
-
-  private buildStatesFilterArgs(state: PRState): string[] {
-    return GRAPHQL_PR_STATES[state].flatMap((s) => ['-f', `states[]=${s}`]);
   }
 }

--- a/backend/modules/projects/projects.module.ts
+++ b/backend/modules/projects/projects.module.ts
@@ -10,8 +10,10 @@ import { CheckoutService } from './checkout-pr-branch.service.js';
 import { ChatSessionsService } from './chat-sessions.service.js';
 import { GitService } from './git.service.js';
 import { ProjectsController } from './projects.controller.js';
+import { GhGraphQLClient } from './gh-graphql.client.js';
 
 export const projectsModule = new ContainerModule((options) => {
+  options.bind(GhGraphQLClient).toSelf();
   options.bind(ProjectRepository).toSelf();
   options.bind(ChatSessionRepository).toSelf();
   options.bind(ProjectsService).toSelf();

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
     "postinstall": "prisma generate",
     "codegen": "graphql-codegen --config codegen.ts",
     "build": "pnpm codegen && tsoa routes && node esbuild.config.mjs",
-    "dev": "dotenv -e ../.env -c -- sh -c 'prisma migrate dev && pnpm codegen && tsoa spec && tsoa routes && (tsx watch --loader ./gql-loader.mjs index.ts || true)'",
+    "dev": "dotenv -e ../.env -c -- sh -c 'prisma migrate dev && tsoa spec && tsoa routes && (tsx watch --loader ./gql-loader.mjs index.ts || true)'",
     "start": "prisma migrate deploy && node dist/index.js",
     "lint": "eslint .",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

- Introduced `GhGraphQLClient` as an injectable class that centralizes all `gh api graphql` calls — handling variable serialization (`-f`/`-F`/array), response parsing, and GraphQL errors-to-`AppError` mapping in one place.
- Refactored `PRListService`, `PRDetailService`, `IssueListService`, and `IssueDetailService` to receive `GhGraphQLClient` via constructor injection, removing duplicated `execFileAsync` / `JSON.parse` / error-check patterns from each service.
- Updated all four service tests to inject a mock client directly (replacing the `vi.mock('node:util')` approach), and added a dedicated `gh-graphql.client.test.ts` covering variable serialization and error mapping.
- Removed `pnpm codegen` from the `dev` script so it no longer runs on every server restart. Codegen still runs automatically in `build`. If you modify `.gql` files, run `pnpm codegen` manually before starting the dev server.

## Data Flow (before → after)

```
Before:
  Service → execFileAsync('gh', ['-f', 'query=...', '-f', 'owner=...', ...])
          → JSON.parse(stdout)
          → manual errors check
          → AppError

After:
  Service → GhGraphQLClient.request(query, variables)
               → execFileAsync('gh', [...buildVariableArgs(variables)])
               → JSON.parse / errors check / mapGhError
               → AppError
```